### PR TITLE
fix: correct GLM-4.7 max context length to 128k

### DIFF
--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -19,7 +19,7 @@
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 200000,
+            "contextWindow": 128000,
             "maxTokens": 8192
           },
           {


### PR DESCRIPTION
## Summary
- Fix GLM-4.7 `contextWindow` from 200k to 128k in `openclaw.json.template`

## Test plan
- [ ] Verify the updated config is picked up correctly by the worker