### PR TITLE
fix: reduce context windows by 10% and add bootstrapMaxChars

### DIFF
--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -19,7 +19,7 @@
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 128000,
+            "contextWindow": 115200,
             "maxTokens": 8192
           },
           {
@@ -33,7 +33,7 @@
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 128000,
+            "contextWindow": 115200,
             "maxTokens": 8192
           },
           {
@@ -47,7 +47,7 @@
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 262144,
+            "contextWindow": 235900,
             "maxTokens": 8192
           }
         ]
@@ -68,7 +68,8 @@
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
-      }
+      },
+      "bootstrapMaxChars": 48000
     }
   },
   "gateway": {


### PR DESCRIPTION
Reduce declared contextWindow values to ~90% of actual limits to prevent hitting token limits when OpenClaw estimates input size. Add bootstrapMaxChars (48000) to cap workspace file injection.

openclaw uses number of chars / 4 for token approximation when calculating token count for input. This causes issues where it could be slightly over the limit of vllm. adding a buffer to prevent that from happening.

- GLM-4.7: 128000 → 115200
- DeepSeek-V3.1: 128000 → 115200
- Qwen3-30B: 262144 → 235900