### PR TITLE
chore: upgrade dstack-ingress to 1.2

### DIFF
--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -7,7 +7,7 @@ services:
     restart: "no"
 
   dstack-ingress:
-    image: dstacktee/dstack-ingress:20250929
+    image: dstacktee/dstack-ingress:1.2@sha256:549d6864ccbde3f35622a4bfbbc54911363650de84f37698d72d85ec4714d6fd
     container_name: dstack-ingress
     network_mode: host
     environment:


### PR DESCRIPTION
## Summary
- Upgrade `dstacktee/dstack-ingress` from `20250929` to `1.2` with SHA pinning
- 1.2 adds input sanitization, configurable proxy settings, and certbot staging support

## Test plan
- [ ] Deploy to dev CVM and verify ingress starts correctly
- [ ] Verify SSL cert issuance works