### PR TITLE
fix: check for self-updates every poll cycle

### DIFF
--- a/updater/updater.sh
+++ b/updater/updater.sh
@@ -41,7 +41,7 @@ COSIGN_ISSUER="${UPDATER_COSIGN_ISSUER:-https://token.actions.githubusercontent.
 HEALTH_URL="${UPDATER_HEALTH_URL:-http://127.0.0.1:8080/health}"
 HEALTH_TIMEOUT="${UPDATER_HEALTH_TIMEOUT:-60}"
 STATE_FILE="${UPDATER_STATE_FILE:-/app/data/updater-state.json}"
-SELF_CHECK_INTERVAL="${UPDATER_SELF_CHECK_INTERVAL:-288}"  # every 24h at 5min polls
+SELF_CHECK_INTERVAL="${UPDATER_SELF_CHECK_INTERVAL:-1}"  # every poll cycle
 BUNDLED_COMPOSE="/app/compose/docker-compose.dstack.yml"
 
 # ── Logging ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Changed `SELF_CHECK_INTERVAL` default from 288 (24h) to 1 (every poll cycle)
- Updater now checks for new self-images every 5 minutes, same as compose-api and worker checks
- Still configurable via `UPDATER_SELF_CHECK_INTERVAL` env var

## Test plan
- [ ] Deploy dev, push a new updater image, verify self-update happens within ~5min