### PR TITLE
fix: restore passwordless sudo for agent user

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
 
 # Create non-root user for OpenClaw agents
 # Use UID 1001 to avoid conflict with default UID 1000
-RUN useradd -m -u 1001 -s /bin/bash agent
+RUN useradd -m -u 1001 -s /bin/bash agent && \
+    echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent
 
 # Global shell for the image (matches agent login shell; used by pnpm setup etc.)
 ENV SHELL=/bin/bash


### PR DESCRIPTION
The sudoers drop-in was lost during earlier refactors that restructured files into worker/. Re-add unconditional NOPASSWD sudo for the agent user so SSH'd users can elevate privileges.