### PR TITLE
feat: use NEAR AI auto model routing instead of hardcoded models

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,22 +210,19 @@ docker compose -f deploy/docker-compose.yml exec openclaw-gateway openclaw model
 The configuration is automatically generated from environment variables on first run. The entrypoint script creates `/home/agent/.openclaw/openclaw.json` with:
 
 - **NEAR AI Cloud** as the model provider
-- **GLM-4.7** (`zai-org/GLM-4.7`) as the default primary model
-- Three models available for agents: GLM-4.7, DeepSeek V3.1, and Qwen3 30B A3B Instruct
+- **auto** (`nearai/auto`) as the default primary model, letting NEAR AI Cloud route to the best available model
 
 ### Available Models
 
-The worker is preconfigured with the following models from NEAR AI Cloud. You can use any of them when sending requests to the gateway or when configuring agents.
+The worker is preconfigured to use NEAR AI Cloud's `auto` routing, which automatically selects the best available model for each request.
 
-| Model | ID | Context | Reasoning | Description |
-|-------|-----|---------|-----------|-------------|
-| **GLM-4.7** (default) | `nearai/zai-org/GLM-4.7` | 200K tokens | Yes | Z.ai GLM 4.7 — strong agentic coding, tool use, and reasoning. Default primary model. |
-| **DeepSeek V3.1** | `nearai/deepseek-ai/DeepSeek-V3.1` | 128K tokens | No | Hybrid model with thinking and non-thinking modes. Good for complex reasoning and tool use. |
-| **Qwen3 30B A3B Instruct** | `nearai/Qwen/Qwen3-30B-A3B-Instruct-2507` | 262K tokens | No | MoE model with long context. Efficient for instruction following and multilingual tasks. |
+| Model | ID | Description |
+|-------|-----|-------------|
+| **auto** (default) | `nearai/auto` | NEAR AI Cloud model routing — automatically selects the best available model. |
 
 **Using a specific model**
 
-- **Primary model**: The default primary model is GLM-4.7. To change it, edit `openclaw.json` (or the template) and set `agents.defaults.model.primary` to one of the IDs above (e.g. `nearai/deepseek-ai/DeepSeek-V3.1`).
+- **Primary model**: The default is `nearai/auto`. To use a specific NEAR AI model, edit `openclaw.json` (or the template) and set `agents.defaults.model.primary` to a specific model ID, then add the model to `models.providers.nearai.models`.
 - **Per-request**: When calling the gateway API (chat completions or responses), specify the `model` parameter in your request body with the desired model ID.
 - **List at runtime**: Run `openclaw models list` inside the container to see all configured models and their IDs.
 

--- a/worker/openclaw.json.template
+++ b/worker/openclaw.json.template
@@ -9,60 +9,8 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "zai-org/GLM-5-FP8",
-            "name": "GLM-5",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": {
-              "input": 0.85,
-              "output": 3.3,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 115200,
-            "maxTokens": 8192
-          },
-          {
-            "id": "zai-org/GLM-4.7",
-            "name": "GLM-4.7",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": {
-              "input": 0.85,
-              "output": 3.3,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 115200,
-            "maxTokens": 8192
-          },
-          {
-            "id": "deepseek-ai/DeepSeek-V3.1",
-            "name": "DeepSeek V3.1",
-            "reasoning": true,
-            "input": ["text"],
-            "cost": {
-              "input": 1.05,
-              "output": 3.1,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 115200,
-            "maxTokens": 8192
-          },
-          {
-            "id": "Qwen/Qwen3-30B-A3B-Instruct-2507",
-            "name": "Qwen3 30B A3B Instruct",
-            "reasoning": false,
-            "input": ["text"],
-            "cost": {
-              "input": 0.15,
-              "output": 0.55,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 235900,
-            "maxTokens": 8192
+            "id": "auto",
+            "name": "auto"
           }
         ]
       }
@@ -71,13 +19,10 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "nearai/zai-org/GLM-5-FP8"
+        "primary": "nearai/auto"
       },
       "models": {
-        "nearai/zai-org/GLM-5-FP8": { "params": { "temperature": 1.0, "top_p": 0.95 } },
-        "nearai/zai-org/GLM-4.7": { "params": { "temperature": 1.0, "top_p": 0.95 } },
-        "nearai/deepseek-ai/DeepSeek-V3.1": { "params": { "temperature": 0.7 } },
-        "nearai/Qwen/Qwen3-30B-A3B-Instruct-2507": { "params": { "temperature": 0.7 } }
+        "nearai/auto": {}
       },
       "workspace": "/home/agent/openclaw",
       "contextTokens": 115200,

--- a/worker/streaming.json
+++ b/worker/streaming.json
@@ -1,6 +1,3 @@
 {
-  "nearai/zai-org/GLM-5-FP8": false,
-  "nearai/zai-org/GLM-4.7": false,
-  "nearai/deepseek-ai/DeepSeek-V3.1": false,
-  "nearai/Qwen/Qwen3-30B-A3B-Instruct-2507": false
+  "nearai/auto": false
 }


### PR DESCRIPTION
## Summary
- Replace 4 hardcoded model entries (GLM-5-FP8, GLM-4.7, DeepSeek-V3.1, Qwen3-30B) with a single `nearai/auto` model
- NEAR AI Cloud handles model routing automatically, selecting the best available model per request
- Simplifies config and decouples the worker from specific model availability

## Changes
- **`worker/openclaw.json.template`** — Single `auto` model entry, `nearai/auto` as primary, models allowlist with `nearai/auto` only
- **`worker/streaming.json`** — Single `nearai/auto: false` entry
- **`README.md`** — Updated model documentation to reflect auto routing

## Test plan
- [x] Docker image builds successfully
- [x] `openclaw doctor` reports no config issues
- [x] Config generates correctly with `nearai/auto` as primary
- [x] Inference works end-to-end via `/v1/chat/completions` API

🤖 Generated with [Claude Code](https://claude.com/claude-code)