### PR TITLE
fix: disable Docker sandbox for ironclaw worker deployments

### DIFF
--- a/ironclaw-worker/entrypoint.sh
+++ b/ironclaw-worker/entrypoint.sh
@@ -74,6 +74,9 @@ export GATEWAY_AUTH_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-changeme}"
 # Disable interactive REPL (no TTY in container; would cause immediate shutdown)
 export CLI_ENABLED=false
 
+# Disable Docker sandbox (no Docker-in-Docker in this environment)
+export SANDBOX_ENABLED=false
+
 # NEAR AI: map compose-api env vars to IronClaw config
 NEARAI_API_URL="${NEARAI_API_URL:-https://cloud-api.near.ai/v1}"
 # Strip trailing /v1 — IronClaw's NEARAI_BASE_URL is the root (it adds /v1 internally)


### PR DESCRIPTION
## Summary

- Set `SANDBOX_ENABLED=false` in `ironclaw-worker/entrypoint.sh` alongside the other disabled-feature exports
- Ironclaw's sandbox defaults to enabled and requires Docker-in-Docker, which is not available in the worker containers

## Test plan

- [ ] Deploy an ironclaw instance and verify it starts without sandbox-related errors in logs
- [ ] Confirm the agent can still execute tools (shell, file ops) directly without the sandbox layer

Made with [Cursor](https://cursor.com)