### PR TITLE
feat: auto-rebuild on upstream IronClaw and OpenClaw releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
         description: 'Image tag override (default: branch-based)'
         required: false
         type: string
+      openclaw_version:
+        description: 'OpenClaw npm version for worker image (default: Dockerfile ARG)'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -108,6 +112,8 @@ jobs:
         if: matrix.build_script
         run: |
           ./deploy/build-image.sh --push "${{ env.IMAGE_REFERENCE }}"
+        env:
+          OPENCLAW_VERSION: ${{ inputs.openclaw_version }}
 
       - name: Get image digest (reproducible)
         if: matrix.build_script

--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -1,0 +1,66 @@
+name: Watch Upstream Releases
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  ironclaw:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest ironclaw release tag
+        id: release
+        run: |
+          TAG=$(gh release view --repo nearai/ironclaw --json tagName -q '.tagName')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Latest ironclaw release: $TAG"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check if already built
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: .ironclaw-release-marker
+          key: ironclaw-release-${{ steps.release.outputs.tag }}
+
+      - name: Trigger build for new release
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "${{ steps.release.outputs.tag }}" > .ironclaw-release-marker
+          gh workflow run build.yml --repo ${{ github.repository }}
+          echo "Triggered build for ironclaw ${{ steps.release.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  openclaw:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest openclaw release tag
+        id: release
+        run: |
+          TAG=$(gh release view --repo openclaw/openclaw --json tagName -q '.tagName')
+          VERSION=${TAG#v}
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest openclaw release: $TAG (version $VERSION)"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check if already built
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: .openclaw-release-marker
+          key: openclaw-release-${{ steps.release.outputs.tag }}
+
+      - name: Trigger build for new release
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "${{ steps.release.outputs.tag }}" > .openclaw-release-marker
+          gh workflow run build.yml --repo ${{ github.repository }} \
+            -f openclaw_version=${{ steps.release.outputs.version }}
+          echo "Triggered build for openclaw ${{ steps.release.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/deploy/build-image.sh
+++ b/deploy/build-image.sh
@@ -49,9 +49,14 @@ fi
 git rev-parse HEAD > .GIT_REV
 
 TEMP_TAG="openclaw-nearai-worker-temp:$(date +%s)"
+BUILD_ARGS=(--build-arg SOURCE_DATE_EPOCH="0")
+if [ -n "${OPENCLAW_VERSION:-}" ]; then
+    BUILD_ARGS+=(--build-arg "OPENCLAW_VERSION=${OPENCLAW_VERSION}")
+fi
+
 docker buildx build --builder buildkit_20 --no-cache --platform linux/amd64 \
     -f worker/Dockerfile \
-    --build-arg SOURCE_DATE_EPOCH="0" \
+    "${BUILD_ARGS[@]}" \
     --output type=oci,dest=./oci.tar,rewrite-timestamp=true \
     --output type=docker,name="$TEMP_TAG",rewrite-timestamp=true ./worker
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -75,8 +75,9 @@ RUN mkdir -p /home/agent/.ssh /home/agent/ssh /home/agent/.openclaw /home/agent/
 # Install pnpm, bun, and OpenClaw as agent user so they go to /home/agent/.npm-global/bin
 # This ensures they are in the agent user's PATH (npm config is set in the same RUN instruction below)
 USER agent
+ARG OPENCLAW_VERSION=2026.2.15
 RUN npm config set prefix "/home/agent/.npm-global" && \
-    npm install -g pnpm bun openclaw@2026.2.15 && \
+    npm install -g pnpm bun openclaw@${OPENCLAW_VERSION} && \
     /home/agent/.npm-global/bin/pnpm setup
 
 # Workaround: NEAR AI streaming bug truncates tool call arguments.


### PR DESCRIPTION
## Summary

- Add `watch-upstream.yml` workflow that polls `nearai/ironclaw` and `openclaw/openclaw` GitHub releases every 30 minutes and triggers `build.yml` when a new release is detected
- Parameterize the OpenClaw npm version in `worker/Dockerfile` via `ARG OPENCLAW_VERSION` so the watch workflow can pass a new version without editing the file
- Thread the build arg through `deploy/build-image.sh` and `build.yml` (`openclaw_version` workflow_dispatch input)

## Test plan

- [ ] Manually trigger the `Watch Upstream Releases` workflow and verify both jobs run (cache miss on first run, cache hit on second)
- [ ] Manually trigger `Build & Deploy` with `-f openclaw_version=2026.2.19` and verify the worker image installs the specified openclaw version
- [ ] Verify the streaming patch verification in the Dockerfile still passes with the new version
- [ ] Confirm a plain `workflow_dispatch` (no `openclaw_version`) still uses the Dockerfile default (`2026.2.15`)

Made with [Cursor](https://cursor.com)