### PR TITLE
fix: use openclaw_domain for ssh_command when set

### DIFF
--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -711,7 +711,8 @@ fn generate_urls(
 }
 
 fn generate_ssh_command(config: &AppConfig, name: &str, ssh_port: u16) -> String {
-    format!("ssh -p {} {}@{}", ssh_port, name, config.host_address)
+    let host = config.openclaw_domain.as_deref().unwrap_or(&config.host_address);
+    format!("ssh -p {} {}@{}", ssh_port, name, host)
 }
 
 // ── SSE helpers ──────────────────────────────────────────────────────
@@ -1963,6 +1964,14 @@ mod tests {
         config.bastion_ssh_port = Some(2222);
         let cmd = generate_ssh_command(&config, "brave-tiger", 19002);
         assert_eq!(cmd, "ssh -p 19002 brave-tiger@localhost");
+    }
+
+    #[test]
+    fn test_generate_ssh_command_with_domain() {
+        let mut config = AppConfig::test_default();
+        config.openclaw_domain = Some("agent0.near.ai".into());
+        let cmd = generate_ssh_command(&config, "brave-tiger", 19002);
+        assert_eq!(cmd, "ssh -p 19002 brave-tiger@agent0.near.ai");
     }
 
     // ── is_valid_instance_name ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- `generate_ssh_command` always used `config.host_address` (defaults to `"localhost"`) even when `OPENCLAW_DOMAIN` was configured, producing incorrect SSH commands (e.g. `ssh -p 19018 mighty-pony@localhost` instead of `ssh -p 19018 mighty-pony@agent0.near.ai`)
- Now mirrors the same domain-aware logic that `generate_urls` already uses: prefer `openclaw_domain` when set, fall back to `host_address`
- Added `test_generate_ssh_command_with_domain` test case

## Test plan

- [ ] `cargo test` passes (all 28 tests including the new one)
- [ ] Deploy with `OPENCLAW_DOMAIN=agent0.near.ai` and verify the `ssh_command` field in instance responses uses `agent0.near.ai` instead of `localhost`
- [ ] Deploy without `OPENCLAW_DOMAIN` and verify `ssh_command` still falls back to `host_address`

Made with [Cursor](https://cursor.com)