### PR TITLE
fix: add actions:write permission to watch-upstream workflow

### DIFF
--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -5,6 +5,9 @@ on:
     - cron: '*/30 * * * *'
   workflow_dispatch:
 
+permissions:
+  actions: write
+
 jobs:
   ironclaw:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: actions: write` to `watch-upstream.yml` so `gh workflow run` can trigger `build.yml`
- Scheduled workflows get read-only `GITHUB_TOKEN` by default, which caused the "Trigger build for new release" step to fail with exit code 1

## Test plan

- [ ] Merge and manually trigger the Watch Upstream Releases workflow
- [ ] Verify both ironclaw and openclaw jobs complete successfully and trigger builds

Made with [Cursor](https://cursor.com)