### PR TITLE
fix: restore default value for IRONCLAW_VERSION ARG

### DIFF
--- a/ironclaw-worker/Dockerfile
+++ b/ironclaw-worker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
       && rm -rf /var/lib/apt/lists/*
 
 # Download prebuilt IronClaw binary from GitHub release
-ARG IRONCLAW_VERSION
+ARG IRONCLAW_VERSION=0.8.0
 RUN curl -fsSL "https://github.com/nearai/ironclaw/releases/download/ironclaw-v${IRONCLAW_VERSION}/ironclaw-x86_64-unknown-linux-gnu.tar.gz" \
     | tar xz -C /usr/local/bin/ ironclaw
 


### PR DESCRIPTION
## Summary

- The previous commit removed the pre-FROM `ARG IRONCLAW_VERSION=0.8.0` but left the post-FROM `ARG IRONCLAW_VERSION` without a default
- Builds triggered without `--build-arg IRONCLAW_VERSION` (e.g., push to main) expand to an empty version, breaking the curl download URL
- Restores the default: `ARG IRONCLAW_VERSION=0.8.0`

## Test plan

- [ ] Merge and verify the Build & Deploy workflow succeeds for `ironclaw-nearai-worker`

Made with [Cursor](https://cursor.com)