### PR TITLE
fix: extract ironclaw binary from nested tarball directory

### DIFF
--- a/ironclaw-worker/Dockerfile
+++ b/ironclaw-worker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
 # Download prebuilt IronClaw binary from GitHub release
 ARG IRONCLAW_VERSION=0.8.0
 RUN curl -fsSL "https://github.com/nearai/ironclaw/releases/download/ironclaw-v${IRONCLAW_VERSION}/ironclaw-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar xz -C /usr/local/bin/ ironclaw
+    | tar xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/ironclaw'
 
 # Create non-root user (UID 1001, matching OpenClaw worker pattern)
 RUN useradd -m -u 1001 -s /bin/bash agent && \


### PR DESCRIPTION
## Summary

- cargo-dist tarballs nest files under `ironclaw-x86_64-unknown-linux-gnu/ironclaw`, not at the root
- The previous `tar xz -C /usr/local/bin/ ironclaw` failed with exit code 2 because there's no top-level `ironclaw` entry
- Fix: use `--strip-components=1` with `--wildcards '*/ironclaw'` to extract just the binary

## Test plan

- [ ] Merge and verify Build & Deploy succeeds for ironclaw-nearai-worker

Made with [Cursor](https://cursor.com)