### PR TITLE
fix: use two-step download+extract for ironclaw release binary

### DIFF
--- a/ironclaw-worker/Dockerfile
+++ b/ironclaw-worker/Dockerfile
@@ -28,7 +28,10 @@ RUN apt-get update && \
 # Download prebuilt IronClaw binary from GitHub release
 ARG IRONCLAW_VERSION=0.8.0
 RUN curl -fsSL "https://github.com/nearai/ironclaw/releases/download/ironclaw-v${IRONCLAW_VERSION}/ironclaw-x86_64-unknown-linux-gnu.tar.gz" \
-    | tar xz --strip-components=1 -C /usr/local/bin/ --wildcards '*/ironclaw'
+      -o /tmp/ironclaw.tar.gz && \
+    tar xzf /tmp/ironclaw.tar.gz -C /tmp && \
+    mv /tmp/ironclaw-*/ironclaw /usr/local/bin/ironclaw && \
+    rm -rf /tmp/ironclaw.tar.gz /tmp/ironclaw-*
 
 # Create non-root user (UID 1001, matching OpenClaw worker pattern)
 RUN useradd -m -u 1001 -s /bin/bash agent && \


### PR DESCRIPTION
## Summary

- Replace piped `curl | tar --wildcards` with a two-step download-then-extract approach
- Download to `/tmp/ironclaw.tar.gz`, extract to `/tmp`, `mv` the binary using shell glob `ironclaw-*/ironclaw`, clean up
- Avoids `--wildcards` flag that fails in Docker's `/bin/sh -c` processing and piping that loses curl error codes

## Test plan

- [ ] Merge and verify Build & Deploy succeeds for ironclaw-nearai-worker
- [ ] Verify `ironclaw --version` works in the built image

Made with [Cursor](https://cursor.com)