### PR TITLE
fix: default bastion SSH port to 15222

### DIFF
--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -328,9 +328,12 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     };
-    let bastion_ssh_port: Option<u16> = std::env::var("BASTION_SSH_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok());
+    let bastion_ssh_port: Option<u16> = Some(
+        std::env::var("BASTION_SSH_PORT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(15222),
+    );
 
     let config = Arc::new(AppConfig {
         admin_token: secrecy::SecretString::from(admin_token),
@@ -1820,7 +1823,7 @@ impl AppConfig {
             ingress_container_name: "test-ingress".to_string(),
             env_override_file: None,
             bastion_ssh_pubkey: None,
-            bastion_ssh_port: None,
+            bastion_ssh_port: Some(15222),
         }
     }
 }
@@ -1962,7 +1965,7 @@ mod tests {
     fn test_generate_ssh_command() {
         let config = AppConfig::test_default();
         let cmd = generate_ssh_command(&config, "brave-tiger", 19002);
-        assert_eq!(cmd, "ssh -p 19002 brave-tiger@localhost");
+        assert_eq!(cmd, "ssh -p 15222 brave-tiger@localhost");
     }
 
     #[test]
@@ -1978,7 +1981,7 @@ mod tests {
         let mut config = AppConfig::test_default();
         config.openclaw_domain = Some("agent0.near.ai".into());
         let cmd = generate_ssh_command(&config, "brave-tiger", 19002);
-        assert_eq!(cmd, "ssh -p 19002 brave-tiger@agent0.near.ai");
+        assert_eq!(cmd, "ssh -p 15222 brave-tiger@agent0.near.ai");
     }
 
     // ── is_valid_instance_name ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- Default `bastion_ssh_port` to `15222` when `BASTION_SSH_PORT` env var is not set
- Previously it fell back to the per-instance port, causing user-facing SSH commands to show port 2222 instead of the correct bastion port 15222
- Updated tests to reflect the new default

## Test plan

- [ ] `cargo test` passes (all 28 tests)
- [ ] Deploy and verify new instances show `ssh -p 15222 <name>@agent0.near.ai`
- [ ] Verify `BASTION_SSH_PORT` env var still overrides the default when set