### PR TITLE
fix: return 503 for stopped instances and cap nginx workers at 8

### DIFF
--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -144,7 +144,13 @@ configs:
           ssl_certificate /etc/letsencrypt/live/${OPENCLAW_DOMAIN}/fullchain.pem;
           ssl_certificate_key /etc/letsencrypt/live/${OPENCLAW_DOMAIN}/privkey.pem;
 
+          default_type application/json;
+
           location / {
+              if ($$openclaw_backend = "") {
+                  return 503 '{"error":"instance_not_available","message":"This instance is stopped or does not exist"}';
+              }
+
               proxy_pass $$openclaw_backend;
               proxy_http_version 1.1;
               proxy_set_header Upgrade $$http_upgrade;

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -144,7 +144,13 @@ configs:
           ssl_certificate /etc/letsencrypt/live/${OPENCLAW_DOMAIN}/fullchain.pem;
           ssl_certificate_key /etc/letsencrypt/live/${OPENCLAW_DOMAIN}/privkey.pem;
 
+          default_type application/json;
+
           location / {
+              if ($$openclaw_backend = "") {
+                  return 503 '{"error":"instance_not_available","message":"This instance is stopped or does not exist"}';
+              }
+
               proxy_pass $$openclaw_backend;
               proxy_http_version 1.1;
               proxy_set_header Upgrade $$http_upgrade;

--- a/ingress/entrypoint.sh
+++ b/ingress/entrypoint.sh
@@ -37,4 +37,4 @@ certbot certonly \
 ) &
 
 # Start nginx in foreground
-exec nginx -g "daemon off;"
+exec nginx -g "worker_processes 8; daemon off;"


### PR DESCRIPTION
## Summary

- Stopped/unknown instance subdomains now return `503 {"error":"instance_not_available"}` instead of crashing nginx with 500 (empty `proxy_pass` from map with no default)
- Capped `worker_processes` at 8 via `-g` flag in entrypoint, down from `auto` (88 on prod hosts) — plenty for an I/O-bound reverse proxy
- Applied to both `docker-compose.dstack.yml` and `docker-compose.local.yml`

## Test plan

- [ ] Build ingress image locally, start with `docker-compose.local.yml`
- [ ] Create an instance, verify normal proxy (200)
- [ ] Stop instance, curl subdomain → expect 503 with JSON error body
- [ ] Curl nonexistent subdomain → same 503
- [ ] Verify `api.$DOMAIN` management API still returns 200
- [ ] `docker exec nginx ps aux | grep 'nginx: worker' | wc -l` → 8