### PR TITLE
feat: use BASTION_SSH_EXTERNAL_PORT for user-facing SSH commands

### DIFF
--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -329,7 +329,8 @@ async fn main() -> anyhow::Result<()> {
         }
     };
     let bastion_ssh_port: Option<u16> = Some(
-        std::env::var("BASTION_SSH_PORT")
+        std::env::var("BASTION_SSH_EXTERNAL_PORT")
+            .or_else(|_| std::env::var("BASTION_SSH_PORT"))
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(15222),

--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -51,6 +51,7 @@ services:
       - ENV_OVERRIDE_FILE=/app/data/.env.overrides
       - BASTION_SSH_PUBKEY_PATH=/app/data/bastion/id_ed25519.pub
       - BASTION_SSH_PORT=${BASTION_SSH_PORT:-2222}
+      - BASTION_SSH_EXTERNAL_PORT=${BASTION_SSH_EXTERNAL_PORT:-${BASTION_SSH_PORT:-2222}}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
       interval: 5s

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -51,6 +51,7 @@ services:
       - ENV_OVERRIDE_FILE=/app/data/.env.overrides
       - BASTION_SSH_PUBKEY_PATH=/app/data/bastion/id_ed25519.pub
       - BASTION_SSH_PORT=${BASTION_SSH_PORT:-2222}
+      - BASTION_SSH_EXTERNAL_PORT=${BASTION_SSH_EXTERNAL_PORT:-${BASTION_SSH_PORT:-2222}}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
       interval: 5s


### PR DESCRIPTION
## Summary
- Add `BASTION_SSH_EXTERNAL_PORT` env var to compose-api so `generate_ssh_command` shows the correct externally-reachable port (e.g. 15222) instead of the internal bastion port (2222)
- Falls back to `BASTION_SSH_PORT` then 15222 for backwards compatibility
- Pass the new env var through both docker-compose files (dstack + local)

## Test plan
- [x] Deployed and verified on prod (agent0.near.ai) — SSH commands now show correct external port
- [ ] Verify local dev compose still works with defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)