### PR TITLE
fix: remove duplicate worker_processes directive from nginx

### DIFF
--- a/ingress/entrypoint.sh
+++ b/ingress/entrypoint.sh
@@ -37,4 +37,4 @@ certbot certonly \
 ) &
 
 # Start nginx in foreground
-exec nginx -g "worker_processes 8; daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
## Summary
- PR #62 added `worker_processes 8` to the `-g` flag in `nginx -g "worker_processes 8; daemon off;"`, but `nginx:alpine` already defines `worker_processes auto` in `/etc/nginx/nginx.conf`
- This causes `nginx: [emerg] "worker_processes" directive is duplicate` and a crash loop in production
- Fix: only pass `daemon off;` via `-g`, letting nginx use its default `worker_processes auto` (which is better than hardcoded 8 on an 88-core machine anyway)

## Test plan
- [ ] Build ingress image locally and verify nginx starts without emerg errors
- [ ] Verify production ingress recovers after updater picks up the new image