### PR TITLE
chore: push dev tag on main, reserve latest for manual dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
             TAG=${GITHUB_REF_NAME#v}
             echo "Using '${TAG}' image tag for ${GITHUB_REF_NAME} tag"
           elif [[ "${GITHUB_REF_TYPE}" == 'branch' ]]; then
-            TAG=$(if [[ "${GITHUB_REF_NAME}" == 'main' ]]; then echo 'latest'; else echo 'dev'; fi)
+            TAG='dev'
             echo "Using '${TAG}' image tag for ${GITHUB_REF_NAME} branch"
           else
             echo "Unsupported ref type: ${GITHUB_REF_TYPE}" >&2


### PR DESCRIPTION
## Summary

- Push to `main` now tags Docker Hub images as `dev` instead of `latest`
- `latest` tag is now only achievable via manual `workflow_dispatch` with `tag: latest`

## Test plan

- [ ] Merge and verify next CI run tags images as `dev` on Docker Hub
- [ ] Manually trigger workflow with `tag: latest` to confirm it still works