### PR TITLE
fix: add UsePAM and AcceptEnv to worker sshd

### DIFF
--- a/ironclaw-worker/entrypoint.sh
+++ b/ironclaw-worker/entrypoint.sh
@@ -46,7 +46,10 @@ if [ -n "${SSH_PUBKEY:-}" ]; then
         -o PasswordAuthentication=no \
         -o PermitRootLogin=no \
         -o PidFile=/home/agent/ssh/sshd.pid \
-        -o StrictModes=yes 2>&1) && SSHD_RC=0 || SSHD_RC=$?
+        -o StrictModes=yes \
+        -o UsePAM=yes \
+        -o AcceptEnv="LANG LC_*" \
+        -o PrintMotd=no 2>&1) && SSHD_RC=0 || SSHD_RC=$?
     if [ "$SSHD_RC" -eq 0 ]; then
         echo "SSH daemon started on port 2222"
     else

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -56,7 +56,10 @@ setup_ssh() {
       -o PasswordAuthentication=no \
       -o PermitRootLogin=no \
       -o PidFile=/home/agent/ssh/sshd.pid \
-      -o StrictModes=yes 2>&1) && SSHD_RC=0 || SSHD_RC=$?
+      -o StrictModes=yes \
+      -o UsePAM=yes \
+      -o AcceptEnv="LANG LC_*" \
+      -o PrintMotd=no 2>&1) && SSHD_RC=0 || SSHD_RC=$?
     if [ "$SSHD_RC" -eq 0 ]; then
       echo "SSH daemon started on port 2222"
     else


### PR DESCRIPTION
## Summary

- Worker containers start sshd with `-f /dev/null`, skipping standard `sshd_config` options
- Without `UsePAM=yes`, the SSH session lacks proper PAM initialization (locale, environment, limits), causing Warp terminal's SSH wrapper to hang on connect
- Adds `UsePAM=yes`, `AcceptEnv="LANG LC_*"`, and `PrintMotd=no` to both `worker/entrypoint.sh` and `ironclaw-worker/entrypoint.sh`

## Test plan

- [ ] Rebuild worker images and deploy to a test instance
- [ ] SSH in from Warp terminal — session should open without hanging
- [ ] SSH in from a standard terminal (iTerm2, default macOS Terminal) — should still work as before
- [ ] Verify `ssh -T user@host 'echo ok'` still works (non-interactive)