### PR TITLE
feat: add default resource limits to worker instances

### DIFF
--- a/compose-api/docker-compose.ironclaw.yml
+++ b/compose-api/docker-compose.ironclaw.yml
@@ -16,6 +16,10 @@ services:
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       SSH_PUBKEY: ${SSH_PUBKEY:-}
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
+    mem_limit: ${MEM_LIMIT:-1g}
+    cpus: ${CPUS:-2}
+    storage_opt:
+      size: ${STORAGE_SIZE:-10G}
     volumes:
       - config:/home/agent/.ironclaw
       - workspace:/home/agent/workspace

--- a/compose-api/docker-compose.worker.yml
+++ b/compose-api/docker-compose.worker.yml
@@ -20,6 +20,10 @@ services:
       SSH_PUBKEY: ${SSH_PUBKEY:-}
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
     command: ["openclaw", "gateway", "run", "--bind", "lan", "--port", "18789"]
+    mem_limit: ${MEM_LIMIT:-1g}
+    cpus: ${CPUS:-2}
+    storage_opt:
+      size: ${STORAGE_SIZE:-10G}
     volumes:
       - config:/home/agent/.openclaw
       - workspace:/home/agent/openclaw

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -24,6 +24,12 @@ pub struct InstanceConfig<'a> {
     pub nearai_api_url: &'a str,
     pub service_type: &'a str,
     pub bastion_ssh_pubkey: Option<&'a str>,
+    /// Memory limit (e.g. "1g", "2g"). Omit to use compose template default.
+    pub mem_limit: Option<&'a str>,
+    /// CPU limit (e.g. "2", "4"). Omit to use compose template default.
+    pub cpus: Option<&'a str>,
+    /// Container storage limit (e.g. "10G", "20G"). Omit to use compose template default.
+    pub storage_size: Option<&'a str>,
 }
 
 /// Manages one Docker Compose project per worker via the `docker compose` CLI.
@@ -132,6 +138,15 @@ impl ComposeManager {
             vars.insert("BASTION_SSH_PUBKEY".into(), bastion_key.into());
         }
         vars.insert("SERVICE_TYPE".into(), cfg.service_type.to_string());
+        if let Some(v) = cfg.mem_limit {
+            vars.insert("MEM_LIMIT".into(), v.into());
+        }
+        if let Some(v) = cfg.cpus {
+            vars.insert("CPUS".into(), v.into());
+        }
+        if let Some(v) = cfg.storage_size {
+            vars.insert("STORAGE_SIZE".into(), v.into());
+        }
         let env_path = self.write_env_file(cfg.name, &vars)?;
 
         // Pull from registry for remote images (contain '/') or digest-pinned references;
@@ -472,6 +487,9 @@ impl ComposeManager {
             image,
             image_digest,
             service_type,
+            mem_limit: None,
+            cpus: None,
+            storage_size: None,
         })
     }
 

--- a/compose-api/src/nginx_conf.rs
+++ b/compose-api/src/nginx_conf.rs
@@ -54,6 +54,9 @@ mod tests {
             image_digest: None,
             nearai_api_url: None,
             service_type: None,
+            mem_limit: None,
+            cpus: None,
+            storage_size: None,
         }
     }
 

--- a/compose-api/src/store.rs
+++ b/compose-api/src/store.rs
@@ -32,6 +32,15 @@ pub struct Instance {
     /// "openclaw" (default) or "ironclaw"
     #[serde(default)]
     pub service_type: Option<String>,
+    /// Memory limit override (e.g. "1g", "2g")
+    #[serde(default)]
+    pub mem_limit: Option<String>,
+    /// CPU limit override (e.g. "2", "4")
+    #[serde(default)]
+    pub cpus: Option<String>,
+    /// Container storage limit override (e.g. "10G", "20G")
+    #[serde(default)]
+    pub storage_size: Option<String>,
 }
 
 #[derive(Debug)]
@@ -149,6 +158,9 @@ mod tests {
             image: None,
             image_digest: None,
             service_type: None,
+            mem_limit: None,
+            cpus: None,
+            storage_size: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Worker instances now default to **1 GB RAM**, **2 vCPUs**, and **10 GB storage** via compose template defaults (`mem_limit`, `cpus`, `storage_opt`)
- Admins can override per-instance by passing `mem_limit`, `cpus`, and `storage_size` in the `POST /instances` request body
- Resource limits are persisted in the instance store and restored on restart/recreate

## Test plan

- [ ] `cargo check` passes
- [ ] `docker compose -f docker-compose.worker.yml config` / `docker-compose.ironclaw.yml config` show correct defaults
- [ ] Deploy a default instance → `docker inspect` shows 1 GB memory, 2 CPUs
- [ ] Deploy with overrides (e.g. `"mem_limit": "4g"`) → inspect shows 4 GB
- [ ] Restart an instance with overrides → limits are preserved