### PR TITLE
fix: remove storage_opt from compose templates

### DIFF
--- a/compose-api/docker-compose.ironclaw.yml
+++ b/compose-api/docker-compose.ironclaw.yml
@@ -18,8 +18,6 @@ services:
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
     mem_limit: ${MEM_LIMIT:-1g}
     cpus: ${CPUS:-2}
-    storage_opt:
-      size: ${STORAGE_SIZE:-10G}
     volumes:
       - config:/home/agent/.ironclaw
       - workspace:/home/agent/workspace

--- a/compose-api/docker-compose.worker.yml
+++ b/compose-api/docker-compose.worker.yml
@@ -22,8 +22,6 @@ services:
     command: ["openclaw", "gateway", "run", "--bind", "lan", "--port", "18789"]
     mem_limit: ${MEM_LIMIT:-1g}
     cpus: ${CPUS:-2}
-    storage_opt:
-      size: ${STORAGE_SIZE:-10G}
     volumes:
       - config:/home/agent/.openclaw
       - workspace:/home/agent/openclaw


### PR DESCRIPTION
## Summary

- `storage_opt` requires overlay2 on XFS with `pquota` mount option and hard-fails on hosts without it (e.g. ext4-backed Docker in dstack CVMs)
- This blocks all instance creation — discovered while testing on dev
- Removes `storage_opt` from both worker and ironclaw compose templates

## Test plan

- [ ] Merge and deploy to dev
- [ ] Create an instance — should succeed without `storage_opt` error