### PR TITLE
fix: lower default cpus to 1 for dstack CVMs

### DIFF
--- a/compose-api/docker-compose.ironclaw.yml
+++ b/compose-api/docker-compose.ironclaw.yml
@@ -17,7 +17,7 @@ services:
       SSH_PUBKEY: ${SSH_PUBKEY:-}
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
     mem_limit: ${MEM_LIMIT:-1g}
-    cpus: ${CPUS:-2}
+    cpus: ${CPUS:-1}
     volumes:
       - config:/home/agent/.ironclaw
       - workspace:/home/agent/workspace

--- a/compose-api/docker-compose.worker.yml
+++ b/compose-api/docker-compose.worker.yml
@@ -21,7 +21,7 @@ services:
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
     command: ["openclaw", "gateway", "run", "--bind", "lan", "--port", "18789"]
     mem_limit: ${MEM_LIMIT:-1g}
-    cpus: ${CPUS:-2}
+    cpus: ${CPUS:-1}
     volumes:
       - config:/home/agent/.openclaw
       - workspace:/home/agent/openclaw


### PR DESCRIPTION
## Summary

- dstack CVMs expose only 1 CPU per container, so the default `cpus: 2` causes `Error response from daemon: Range of CPUs is from 0.01 to 1.00` on every instance creation
- Lowers default from 2 to 1 in both worker and ironclaw compose templates
- Admins can still override via `cpus` API parameter for hosts with more CPUs

## Test plan

- [ ] Deploy to dev/prod
- [ ] Create an instance without passing `cpus` — should succeed