### PR TITLE
chore: bump ironclaw to v0.11.1

### DIFF
--- a/ironclaw-worker/Dockerfile
+++ b/ironclaw-worker/Dockerfile
@@ -1,7 +1,7 @@
 # IronClaw worker image for compose-api deployment.
 #
 # Downloads a prebuilt binary from GitHub releases:
-#   docker build --build-arg IRONCLAW_VERSION=0.9.0 \
+#   docker build --build-arg IRONCLAW_VERSION=0.11.1 \
 #     -t ironclaw-nearai-worker:local ironclaw-worker/
 
 FROM debian:bookworm-slim
@@ -26,7 +26,7 @@ RUN apt-get update && \
       && rm -rf /var/lib/apt/lists/*
 
 # Download prebuilt IronClaw binary from GitHub release
-ARG IRONCLAW_VERSION=0.9.0
+ARG IRONCLAW_VERSION=0.11.1
 RUN curl -fsSL "https://github.com/nearai/ironclaw/releases/download/v${IRONCLAW_VERSION}/ironclaw-x86_64-unknown-linux-gnu.tar.gz" \
       -o /tmp/ironclaw.tar.gz && \
     tar xzf /tmp/ironclaw.tar.gz -C /tmp && \


### PR DESCRIPTION
## Summary

- Bumps ironclaw from v0.9.0 to v0.11.1 (https://github.com/nearai/ironclaw/releases/tag/v0.11.1)
- New instances will pick up v0.11.1 after the image is built and the updater syncs the digest

## Test plan

- [ ] CI builds the new ironclaw-nearai-worker image
- [ ] Create a new instance and verify `ironclaw --version` returns `0.11.1`