### PR TITLE
fix: auto-resolve latest openclaw and ironclaw versions in CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,18 @@ jobs:
           fi
           echo "IMAGE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
+      # Resolve latest ironclaw version from GitHub releases when not explicitly provided
+      - name: Resolve ironclaw version
+        if: matrix.name == 'ironclaw-nearai-worker' && !inputs.ironclaw_version
+        id: ironclaw
+        run: |
+          TAG=$(gh release view --repo nearai/ironclaw --json tagName -q '.tagName')
+          VERSION=$(echo "$TAG" | sed 's/^[^0-9]*//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved latest ironclaw version: $VERSION (tag: $TAG)"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       # Standard Docker build path (compose-api, updater)
       - name: Build and push image
         if: ${{ !matrix.build_script }}
@@ -132,7 +144,7 @@ jobs:
           tags: ${{ env.IMAGE_REFERENCE }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-            ${{ inputs.ironclaw_version && format('IRONCLAW_VERSION={0}', inputs.ironclaw_version) || '' }}
+            ${{ (inputs.ironclaw_version || steps.ironclaw.outputs.version) && format('IRONCLAW_VERSION={0}', inputs.ironclaw_version || steps.ironclaw.outputs.version) || '' }}
 
       - name: Get image digest (standard)
         if: ${{ !matrix.build_script }}


### PR DESCRIPTION
## Summary

- Every push to main was rebuilding worker images with stale Dockerfile `ARG` defaults, overwriting correct versions set by `watch-upstream.yml`
- Now `build.yml` fetches the latest release from GitHub for both **openclaw** (`openclaw/openclaw`) and **ironclaw** (`nearai/ironclaw`) when no explicit version is provided
- Explicit `workflow_dispatch` inputs still take priority when provided by watch-upstream

## Test plan

- [ ] Merge and verify the next push-triggered build resolves latest versions in CI logs
- [ ] Verify `workflow_dispatch` with explicit versions still overrides correctly
- [ ] Deploy new instances and confirm they run the latest openclaw and ironclaw