### PR TITLE
chore: increase default mem_limit to 4g for worker instances

### DIFF
--- a/compose-api/docker-compose.ironclaw.yml
+++ b/compose-api/docker-compose.ironclaw.yml
@@ -16,7 +16,7 @@ services:
       OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
       SSH_PUBKEY: ${SSH_PUBKEY:-}
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
-    mem_limit: ${MEM_LIMIT:-1g}
+    mem_limit: ${MEM_LIMIT:-4g}
     cpus: ${CPUS:-1}
     volumes:
       - config:/home/agent/.ironclaw

--- a/compose-api/docker-compose.worker.yml
+++ b/compose-api/docker-compose.worker.yml
@@ -20,7 +20,7 @@ services:
       SSH_PUBKEY: ${SSH_PUBKEY:-}
       BASTION_SSH_PUBKEY: ${BASTION_SSH_PUBKEY:-}
     command: ["openclaw", "gateway", "run", "--bind", "lan", "--port", "18789"]
-    mem_limit: ${MEM_LIMIT:-1g}
+    mem_limit: ${MEM_LIMIT:-4g}
     cpus: ${CPUS:-1}
     volumes:
       - config:/home/agent/.openclaw


### PR DESCRIPTION
## Summary

- Increases default memory limit for openclaw and ironclaw worker containers from 1g to 4g
- Admins can still override via the `mem_limit` field in the API request

## Test plan

- [ ] Deploy a new instance without specifying `mem_limit` — `docker inspect` should show 4 GB memory limit
- [ ] Deploy with explicit `mem_limit` override — should still respect the provided value