### PR TITLE
fix: add controlUi origin fallback for openclaw 2026.2.23+

### DIFF
--- a/worker/openclaw.json.template
+++ b/worker/openclaw.json.template
@@ -50,6 +50,9 @@
     },
     "bind": "${OPENCLAW_GATEWAY_BIND}",
     "port": 18789,
+    "controlUi": {
+      "dangerouslyAllowHostHeaderOriginFallback": true
+    },
     "http": {
       "endpoints": {
         "chatCompletions": {


### PR DESCRIPTION
## Summary

- Adds `gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback: true` to the config template
- Required since openclaw `2026.2.23`, which enforces explicit `allowedOrigins` for non-loopback gateways

## Root cause

1. `watch-upstream.yml` detected openclaw `2026.2.23` and triggered a build
2. Auto-updater pulled the new image and restarted instances
3. Newer openclaw requires `gateway.controlUi.allowedOrigins` for `--bind lan`
4. Config template didn't have it → gateway crash-loops on startup
5. 6 staging instances affected (+ `fierce-mule` OOMing separately)

The host-header fallback is safe here because each instance is behind nginx on its own subdomain.

## Affected instances (staging)

| Instance | Error |
|----------|-------|
| `pale-hen` | `allowedOrigins` |
| `steel-snake` | `allowedOrigins` |
| `solid-horse` | `allowedOrigins` |
| `kind-pony` | `allowedOrigins` |
| `noble-duck` | `allowedOrigins` |
| `happy-seal` | `allowedOrigins` |

## Test plan

- [ ] Merge and rebuild worker image
- [ ] Restart affected staging instances with `OPENCLAW_FORCE_CONFIG_REGEN=1` (config is one-shot, needs regen)
- [ ] Verify gateway starts without `allowedOrigins` error
- [ ] Verify Control UI is accessible via subdomain

🤖 Generated with [Claude Code](https://claude.com/claude-code)