### PR TITLE
Pin upstream dependency versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,19 +120,7 @@ jobs:
           fi
           echo "IMAGE_DIGEST=${DIGEST}" >> "$GITHUB_ENV"
 
-      # Resolve latest ironclaw version from GitHub releases when not explicitly provided
-      - name: Resolve ironclaw version
-        if: matrix.name == 'ironclaw-nearai-worker' && !inputs.ironclaw_version
-        id: ironclaw
-        run: |
-          TAG=$(gh release view --repo nearai/ironclaw --json tagName -q '.tagName')
-          VERSION=$(echo "$TAG" | sed 's/^[^0-9]*//')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Resolved latest ironclaw version: $VERSION (tag: $TAG)"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      # Standard Docker build path (compose-api, updater)
+      # Standard Docker build path (compose-api, updater, ironclaw-worker, ingress, bastion)
       - name: Build and push image
         if: ${{ !matrix.build_script }}
         uses: docker/build-push-action@v6
@@ -144,7 +132,7 @@ jobs:
           tags: ${{ env.IMAGE_REFERENCE }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
-            ${{ (inputs.ironclaw_version || steps.ironclaw.outputs.version) && format('IRONCLAW_VERSION={0}', inputs.ironclaw_version || steps.ironclaw.outputs.version) || '' }}
+            ${{ inputs.ironclaw_version && format('IRONCLAW_VERSION={0}', inputs.ironclaw_version) || '' }}
 
       - name: Get image digest (standard)
         if: ${{ !matrix.build_script }}

--- a/.github/workflows/watch-upstream.yml
+++ b/.github/workflows/watch-upstream.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
+  contents: write
+  pull-requests: write
 
 jobs:
   check-ironclaw:
@@ -28,7 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Check if already built
+      - name: Check if already seen
         id: cache
         uses: actions/cache@v4
         with:
@@ -57,7 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Check if already built
+      - name: Check if already seen
         id: cache
         uses: actions/cache@v4
         with:
@@ -68,25 +69,81 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: echo "${{ steps.release.outputs.tag }}" > .openclaw-release-marker
 
-  trigger-build:
+  version-bump-pr:
     needs: [check-ironclaw, check-openclaw]
     if: needs.check-ironclaw.outputs.new_release == 'true' || needs.check-openclaw.outputs.new_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger single build
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bump ironclaw version in Dockerfile
+        if: needs.check-ironclaw.outputs.new_release == 'true'
         run: |
-          ARGS=""
+          VERSION="${{ needs.check-ironclaw.outputs.version }}"
+          sed -i "s/^ARG IRONCLAW_VERSION=.*/ARG IRONCLAW_VERSION=${VERSION}/" ironclaw-worker/Dockerfile
+          echo "Updated ironclaw-worker/Dockerfile: IRONCLAW_VERSION=${VERSION}"
+
+      - name: Bump openclaw version in Dockerfile
+        if: needs.check-openclaw.outputs.new_release == 'true'
+        run: |
+          VERSION="${{ needs.check-openclaw.outputs.version }}"
+          sed -i "s/^ARG OPENCLAW_VERSION=.*/ARG OPENCLAW_VERSION=${VERSION}/" worker/Dockerfile
+          echo "Updated worker/Dockerfile: OPENCLAW_VERSION=${VERSION}"
+
+      - name: Validate changes were applied
+        run: |
           if [[ "${{ needs.check-ironclaw.outputs.new_release }}" == "true" ]]; then
-            ARGS="$ARGS -f ironclaw_version=${{ needs.check-ironclaw.outputs.version }}"
+            if git diff --quiet ironclaw-worker/Dockerfile; then
+              echo "ERROR: sed made no change to ironclaw-worker/Dockerfile" >&2
+              exit 1
+            fi
           fi
           if [[ "${{ needs.check-openclaw.outputs.new_release }}" == "true" ]]; then
-            ARGS="$ARGS -f openclaw_version=${{ needs.check-openclaw.outputs.version }}"
+            if git diff --quiet worker/Dockerfile; then
+              echo "ERROR: sed made no change to worker/Dockerfile" >&2
+              exit 1
+            fi
           fi
 
-          gh workflow run build.yml --repo ${{ github.repository }} $ARGS
+      - name: Create pull request
+        run: |
+          NL=$'\n'
+          COMPONENTS=""
+          BODY="Automated version bump detected by watch-upstream.${NL}${NL}## Changes${NL}"
 
-          echo "Triggered build (ironclaw=${{ needs.check-ironclaw.outputs.new_release }}, openclaw=${{ needs.check-openclaw.outputs.new_release }})"
-          [[ "${{ needs.check-ironclaw.outputs.new_release }}" == "true" ]] && echo "  ironclaw: ${{ needs.check-ironclaw.outputs.tag }}"
-          [[ "${{ needs.check-openclaw.outputs.new_release }}" == "true" ]] && echo "  openclaw: ${{ needs.check-openclaw.outputs.tag }}"
+          if [[ "${{ needs.check-ironclaw.outputs.new_release }}" == "true" ]]; then
+            COMPONENTS="ironclaw-${{ needs.check-ironclaw.outputs.version }}"
+            BODY="${BODY}- **IronClaw**: \`${{ needs.check-ironclaw.outputs.version }}\` ([release](https://github.com/nearai/ironclaw/releases/tag/${{ needs.check-ironclaw.outputs.tag }}))${NL}"
+          fi
+
+          if [[ "${{ needs.check-openclaw.outputs.new_release }}" == "true" ]]; then
+            [[ -n "$COMPONENTS" ]] && COMPONENTS="${COMPONENTS}-"
+            COMPONENTS="${COMPONENTS}openclaw-${{ needs.check-openclaw.outputs.version }}"
+            BODY="${BODY}- **OpenClaw**: \`${{ needs.check-openclaw.outputs.version }}\` ([release](https://github.com/openclaw/openclaw/releases/tag/${{ needs.check-openclaw.outputs.tag }}))${NL}"
+          fi
+
+          BRANCH="deps/bump-${COMPONENTS}"
+          TITLE="Bump ${COMPONENTS}"
+
+          # Skip if a PR already exists for this branch (handles cache expiry re-detection)
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number -q '.[0].number' || true)
+          if [[ -n "$EXISTING" ]]; then
+            echo "PR #${EXISTING} already exists for branch ${BRANCH}, skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add ironclaw-worker/Dockerfile worker/Dockerfile
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          printf '%s' "$BODY" | gh pr create \
+            --title "$TITLE" \
+            --body-file - \
+            --head "$BRANCH" \
+            --base main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -75,7 +75,7 @@ RUN mkdir -p /home/agent/.ssh /home/agent/ssh /home/agent/.openclaw /home/agent/
 # Install pnpm, bun, and OpenClaw as agent user so they go to /home/agent/.npm-global/bin
 # This ensures they are in the agent user's PATH (npm config is set in the same RUN instruction below)
 USER agent
-ARG OPENCLAW_VERSION=2026.2.15
+ARG OPENCLAW_VERSION=2026.2.22
 RUN npm config set prefix "/home/agent/.npm-global" && \
     npm install -g pnpm bun openclaw@${OPENCLAW_VERSION} && \
     /home/agent/.npm-global/bin/pnpm setup


### PR DESCRIPTION
## Summary
- **watch-upstream**: Replace `trigger-build` job with `version-bump-pr` — new upstream releases now create a PR bumping Dockerfile ARG defaults instead of auto-triggering builds. Includes duplicate PR detection and sed change validation.
- **build.yml**: Remove ironclaw auto-resolve step so builds use the Dockerfile ARG default instead of always fetching the latest upstream release.
- **worker/Dockerfile**: Bump OpenClaw from `2026.2.15` to `2026.2.22`.

## Motivation
Upstream OpenClaw/IronClaw releases were automatically flowing through to dev with no human review gate. This could introduce backwards-incompatible changes. Now:
1. Dockerfile ARG defaults are the source of truth for pinned versions
2. New upstream releases create a PR that must be reviewed and merged
3. Push-to-main builds use Dockerfile defaults (manual `workflow_dispatch` override still works)
4. Dev updater auto-deploys whatever lands on the `:dev` tag — the gate is what merges to `main`

## Testing performed
Triggered `watch-upstream.yml` via `workflow_dispatch` on this branch ([run #22426218789](https://github.com/nearai/openclaw-nearai-worker/actions/runs/22426218789)). Results:

- [x] `check-ironclaw`: detected `v0.11.1`, cache hit → `new_release=false` (correct, already at latest)
- [x] `check-openclaw`: detected `v2026.2.24`, cache miss → `new_release=true` (correct, differs from pinned `2026.2.22`)
- [x] `version-bump-pr` job triggered correctly (only when `new_release=true`)
- [x] `sed` bumped `ARG OPENCLAW_VERSION` from `2026.2.22` to `2026.2.24` in `worker/Dockerfile`
- [x] Validation step confirmed the Dockerfile was actually modified
- [x] Commit created: `Bump openclaw-2026.2.24` (1 file changed, 1 insertion, 1 deletion)
- [x] Branch `deps/bump-openclaw-2026.2.24` pushed successfully
- [ ] PR creation failed with: `GitHub Actions is not permitted to create or approve pull requests` — **requires enabling** "Allow GitHub Actions to create and approve pull requests" in repo Settings → Actions → General → Workflow permissions

## Setup required after merge
Enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** so the workflow can create version-bump PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)