### PR TITLE
feat: recover agent instance from backup

### DIFF
--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -1,14 +1,44 @@
-use std::io::Write;
+use std::io::{Cursor, Read, Write};
 use std::str::FromStr;
 use std::time::Duration;
 
+use age::ssh::Identity;
+use age::{Callbacks, Decryptor, Identity as AgeIdentity};
+use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::presigning::PresigningConfig;
 use chrono::{DateTime, Utc};
+use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
+use secrecy::SecretString;
 use serde::Serialize;
 
 use crate::error::ApiError;
+
+/// Max plaintext instance data (tar) after decrypt+decompress — keep in sync with `MAX_EXPORT_BYTES` in main.
+const MAX_BACKUP_PLAINTEXT_BYTES: usize = 512 * 1024 * 1024;
+/// Max ciphertext size accepted from S3 (slightly above plaintext cap).
+const MAX_BACKUP_CIPHERTEXT_BYTES: usize = 520 * 1024 * 1024;
+const MAX_SSH_PRIVATE_KEY_BYTES: usize = 256 * 1024;
+
+#[derive(Clone)]
+struct StaticPassphraseCallbacks(SecretString);
+
+impl Callbacks for StaticPassphraseCallbacks {
+    fn display_message(&self, _message: &str) {}
+
+    fn confirm(&self, _message: &str, _yes: &str, _no: Option<&str>) -> Option<bool> {
+        None
+    }
+
+    fn request_public_string(&self, _description: &str) -> Option<String> {
+        None
+    }
+
+    fn request_passphrase(&self, _description: &str) -> Option<SecretString> {
+        Some(self.0.clone())
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackupInfo {
@@ -158,6 +188,133 @@ impl BackupManager {
 
         Ok(presigned.uri().to_string())
     }
+
+    /// Download encrypted backup object bytes from S3.
+    pub async fn fetch_backup_ciphertext(
+        &self,
+        instance_name: &str,
+        backup_id: &str,
+    ) -> Result<Vec<u8>, ApiError> {
+        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
+        let resp = self
+            .s3
+            .get_object()
+            .bucket(&self.bucket)
+            .key(&key)
+            .send()
+            .await
+            .map_err(|e| match &e {
+                SdkError::ServiceError(se) if se.err().is_no_such_key() => {
+                    ApiError::NotFound(format!(
+                        "Backup '{}' not found for instance '{}'",
+                        backup_id, instance_name
+                    ))
+                }
+                _ => ApiError::Internal(format!("S3 download failed: {}", e)),
+            })?;
+
+        let agg = resp
+            .body
+            .collect()
+            .await
+            .map_err(|e| ApiError::Internal(format!("S3 body read failed: {}", e)))?;
+        let bytes = agg.into_bytes().to_vec();
+        if bytes.len() > MAX_BACKUP_CIPHERTEXT_BYTES {
+            return Err(ApiError::BadRequest(format!(
+                "Backup object too large (max {} MiB ciphertext)",
+                MAX_BACKUP_CIPHERTEXT_BYTES / (1024 * 1024)
+            )));
+        }
+        Ok(bytes)
+    }
+}
+
+/// Decrypt an age backup (SSH recipient) and decompress gzip to the raw tar archive
+/// produced by `export_instance_data`.
+pub fn decrypt_backup_to_tar(
+    ciphertext: &[u8],
+    ssh_private_key: &str,
+    ssh_key_passphrase: Option<&str>,
+) -> Result<Vec<u8>, ApiError> {
+    if ssh_private_key.is_empty() {
+        return Err(ApiError::BadRequest("ssh_private_key is required".into()));
+    }
+    if ssh_private_key.len() > MAX_SSH_PRIVATE_KEY_BYTES {
+        return Err(ApiError::BadRequest("ssh_private_key is too large".into()));
+    }
+
+    let identity =
+        Identity::from_buffer(Cursor::new(ssh_private_key.as_bytes()), None).map_err(|e| {
+            ApiError::BadRequest(format!(
+                "invalid SSH private key (expected OpenSSH or PEM): {}",
+                e
+            ))
+        })?;
+
+    if matches!(&identity, Identity::Unsupported(_)) {
+        return Err(ApiError::BadRequest(
+            "SSH private key type is not supported for backup decryption (use ed25519 or RSA)"
+                .into(),
+        ));
+    }
+
+    let decryptor = Decryptor::new_buffered(Cursor::new(ciphertext)).map_err(|e| {
+        ApiError::BadRequest(format!("file is not a valid age-encrypted backup: {}", e))
+    })?;
+
+    let mut gz_plain = Vec::new();
+    if matches!(&identity, Identity::Encrypted(_)) {
+        let passphrase = ssh_key_passphrase.ok_or_else(|| {
+            ApiError::BadRequest(
+                "SSH private key is passphrase-protected; provide ssh_key_passphrase".into(),
+            )
+        })?;
+        let cb =
+            StaticPassphraseCallbacks(SecretString::new(passphrase.to_string().into_boxed_str()));
+        let id = identity.with_callbacks(cb);
+        let mut r = decryptor
+            .decrypt(std::iter::once(&id as &dyn AgeIdentity))
+            .map_err(|e| {
+                ApiError::BadRequest(format!(
+                    "decryption failed (wrong key or passphrase): {}",
+                    e
+                ))
+            })?;
+        r.read_to_end(&mut gz_plain)
+            .map_err(|e| ApiError::Internal(format!("read decrypted backup stream: {}", e)))?;
+    } else {
+        let mut r = decryptor
+            .decrypt(std::iter::once(&identity as &dyn AgeIdentity))
+            .map_err(|e| {
+                ApiError::BadRequest(format!(
+                    "decryption failed (SSH private key does not match backup): {}",
+                    e
+                ))
+            })?;
+        r.read_to_end(&mut gz_plain)
+            .map_err(|e| ApiError::Internal(format!("read decrypted backup stream: {}", e)))?;
+    }
+
+    if gz_plain.len() > MAX_BACKUP_CIPHERTEXT_BYTES {
+        return Err(ApiError::BadRequest(
+            "decrypted payload exceeds configured size limit".into(),
+        ));
+    }
+
+    let mut tar = Vec::new();
+    let mut decoder = GzDecoder::new(gz_plain.as_slice());
+    decoder.read_to_end(&mut tar).map_err(|e| {
+        ApiError::BadRequest(format!("backup is not valid gzip after decrypt: {}", e))
+    })?;
+
+    if tar.len() > MAX_BACKUP_PLAINTEXT_BYTES {
+        return Err(ApiError::BadRequest(format!(
+            "restored tar exceeds {} MiB limit",
+            MAX_BACKUP_PLAINTEXT_BYTES / (1024 * 1024)
+        )));
+    }
+
+    Ok(tar)
 }
 
 /// Encrypt data using an SSH public key via the `age` crate.

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -881,6 +881,106 @@ impl ComposeManager {
         Ok(())
     }
 
+    /// Restore instance data from a plaintext tar (same layout as [`Self::export_instance_data`])
+    /// into Docker named volumes while the gateway container is stopped.
+    ///
+    /// The caller should start the gateway afterward (e.g. [`Self::start`]).
+    pub fn restore_instance_data_from_tar_volumes(
+        &self,
+        name: &str,
+        service_type: Option<&str>,
+        image: &str,
+        tar_bytes: &[u8],
+    ) -> Result<(), ApiError> {
+        if !crate::is_valid_instance_name(name) {
+            return Err(ApiError::BadRequest(format!(
+                "Invalid instance name: '{}'",
+                name
+            )));
+        }
+
+        let container = format!("openclaw-{}-gateway-1", name);
+        let _ = Command::new("docker")
+            .args(["stop", &container])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+
+        let vol_config = format!("openclaw-{}_config", name);
+        let vol_workspace = format!("openclaw-{}_workspace", name);
+
+        let (config_mount, workspace_mount) = match service_type {
+            Some("ironclaw") => ("/restore/.ironclaw", "/restore/workspace"),
+            Some("openclaw") => ("/restore/.openclaw", "/restore/openclaw"),
+            None => {
+                return Err(ApiError::Internal(
+                    "restore requires service_type (openclaw or ironclaw)".into(),
+                ));
+            }
+            Some(other) => {
+                return Err(ApiError::BadRequest(format!(
+                    "Unknown service_type for restore: '{}'",
+                    other
+                )));
+            }
+        };
+
+        let v1 = format!("{}:{}", vol_config, config_mount);
+        let v2 = format!("{}:{}", vol_workspace, workspace_mount);
+
+        let mut child = Command::new("docker")
+            .args([
+                "run",
+                "--rm",
+                "-i",
+                "-u",
+                "agent",
+                "--entrypoint",
+                "tar",
+                "-v",
+                &v1,
+                "-v",
+                &v2,
+                image,
+                "xf",
+                "-",
+                "-C",
+                "/restore",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ApiError::Internal(format!("docker run tar (restore): {}", e)))?;
+
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| ApiError::Internal("restore: no stdin".into()))?;
+            stdin
+                .write_all(tar_bytes)
+                .map_err(|e| ApiError::Internal(format!("restore tar stdin: {}", e)))?;
+            stdin
+                .flush()
+                .map_err(|e| ApiError::Internal(format!("restore tar flush: {}", e)))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| ApiError::Internal(format!("restore tar wait: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ApiError::Internal(format!(
+                "docker run tar restore failed: {}",
+                stderr
+            )));
+        }
+
+        Ok(())
+    }
+
     // ── discovery ─────────────────────────────────────────────────────
 
     /// Discover all managed instances from Docker containers.

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -45,7 +45,7 @@ mod names;
 mod nginx_conf;
 mod store;
 
-use backup::BackupManager;
+use backup::{decrypt_backup_to_tar, BackupManager};
 use compose::{ComposeManager, DEFAULT_NEARAI_API_URL};
 use error::ApiError;
 use store::{Instance, InstanceStore, PortRange};
@@ -72,6 +72,7 @@ use store::{Instance, InstanceStore, PortRange};
         create_backup_endpoint,
         list_backups_endpoint,
         download_backup_endpoint,
+        restore_backup_endpoint,
         get_config,
         set_config,
         delete_config_key,
@@ -95,6 +96,7 @@ use store::{Instance, InstanceStore, PortRange};
         BackupInfoResponse,
         BackupListResponse,
         BackupDownloadResponse,
+        RestoreBackupRequest,
         SseEvent,
         ErrorResponse,
         RestartServiceResponse,
@@ -351,6 +353,29 @@ impl AppState {
         tokio::task::spawn_blocking(move || compose.import_instance_data(&name, &tar_bytes))
             .await
             .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
+    }
+
+    async fn compose_restore_instance_data_from_tar_volumes(
+        &self,
+        name: &str,
+        service_type: Option<&str>,
+        image: &str,
+        tar_bytes: Vec<u8>,
+    ) -> Result<(), ApiError> {
+        let compose = self.compose.clone();
+        let name = name.to_string();
+        let service_type = service_type.map(|s| s.to_string());
+        let image = image.to_string();
+        tokio::task::spawn_blocking(move || {
+            compose.restore_instance_data_from_tar_volumes(
+                &name,
+                service_type.as_deref(),
+                &image,
+                &tar_bytes,
+            )
+        })
+        .await
+        .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
     }
 }
 
@@ -1676,6 +1701,10 @@ async fn main() -> anyhow::Result<()> {
             .route(
                 "/instances/{name}/backups/{id}",
                 get(download_backup_endpoint),
+            )
+            .route(
+                "/instances/{name}/restore/{id}",
+                post(restore_backup_endpoint),
             );
     }
 
@@ -1913,6 +1942,15 @@ struct BackupListResponse {
 struct BackupDownloadResponse {
     url: String,
     expires_in_seconds: u64,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+struct RestoreBackupRequest {
+    /// OpenSSH or PEM private key matching the instance `ssh_pubkey` used when the backup was created.
+    ssh_private_key: String,
+    /// Passphrase for the private key when it is stored encrypted (OpenSSH `-o` format).
+    #[serde(default)]
+    ssh_key_passphrase: Option<String>,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -3267,6 +3305,235 @@ async fn download_backup_endpoint(
         url,
         expires_in_seconds: 3600,
     }))
+}
+
+#[utoipa::path(post, path = "/instances/{name}/restore/{id}", tag = "Backups",
+    params(
+        ("name" = String, Path, description = "Instance name"),
+        ("id" = String, Path, description = "Backup ID (timestamp)"),
+    ),
+    request_body = RestoreBackupRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "SSE stream of restore progress", content_type = "text/event-stream", body = SseEvent),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Instance or backup not found", body = ErrorResponse),
+        (status = 409, description = "Concurrent upgrade/restore", body = ErrorResponse),
+        (status = 501, description = "Backups not configured", body = ErrorResponse),
+    )
+)]
+async fn restore_backup_endpoint(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path((name, backup_id)): Path<(String, String)>,
+    Json(req): Json<RestoreBackupRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if !is_valid_instance_name(&name) {
+        return Err(ApiError::BadRequest(format!(
+            "Invalid instance name: '{}'",
+            name
+        )));
+    }
+
+    let backup_mgr = state
+        .backup
+        .as_ref()
+        .ok_or_else(|| ApiError::NotImplemented("Backup not configured".into()))?
+        .clone();
+
+    let inst = {
+        let store = state.store.read().await;
+        store.get(&name).cloned()
+    };
+    let inst = inst.ok_or_else(|| ApiError::NotFound(format!("Instance '{}' not found", name)))?;
+
+    if inst.service_type.as_deref().is_none() {
+        return Err(ApiError::BadRequest(
+            "Instance has no service_type; set SERVICE_TYPE in .env before restore".into(),
+        ));
+    }
+
+    let mut upgrading = state.upgrading.lock().await;
+    if !upgrading.insert(name.clone()) {
+        return Err(ApiError::Conflict(format!(
+            "Instance '{}' is already being upgraded or restored",
+            name
+        )));
+    }
+    drop(upgrading);
+
+    {
+        let mut store = state.store.write().await;
+        let _ = store.set_active(&name, false);
+    }
+    update_nginx_now(&state).await;
+
+    let worker_image = inst
+        .image
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            if inst.service_type.as_deref() == Some("ironclaw") {
+                state.config.ironclaw_image.clone()
+            } else {
+                state.config.openclaw_image.clone()
+            }
+        });
+
+    let passphrase_owned = req
+        .ssh_key_passphrase
+        .clone()
+        .filter(|s| !s.trim().is_empty());
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Event>(16);
+
+    {
+        let state = state.clone();
+        let name = name.clone();
+        let backup_id = backup_id.clone();
+        let inst = inst.clone();
+        let ssh_private_key = req.ssh_private_key.clone();
+        tokio::spawn(async move {
+            async fn release_upgrading(state: &AppState, name: &str) {
+                state.upgrading.lock().await.remove(name);
+            }
+
+            let _ = tx
+                .send(sse_stage(
+                    "downloading",
+                    "Downloading encrypted backup from storage...",
+                ))
+                .await;
+
+            let ciphertext = match backup_mgr.fetch_backup_ciphertext(&name, &backup_id).await {
+                Ok(b) => b,
+                Err(e) => {
+                    let _ = tx.send(sse_error(&e.to_string())).await;
+                    release_upgrading(&state, &name).await;
+                    return;
+                }
+            };
+
+            let _ = tx
+                .send(sse_stage(
+                    "decrypting",
+                    "Decrypting backup with SSH private key...",
+                ))
+                .await;
+
+            let tar_result = tokio::task::spawn_blocking(move || {
+                decrypt_backup_to_tar(&ciphertext, &ssh_private_key, passphrase_owned.as_deref())
+            })
+            .await;
+
+            let tar_bytes = match tar_result {
+                Ok(Ok(t)) => t,
+                Ok(Err(e)) => {
+                    let _ = tx.send(sse_error(&e.to_string())).await;
+                    release_upgrading(&state, &name).await;
+                    return;
+                }
+                Err(e) => {
+                    let _ = tx
+                        .send(sse_error(&format!("decrypt task failed: {}", e)))
+                        .await;
+                    release_upgrading(&state, &name).await;
+                    return;
+                }
+            };
+
+            let _ = tx
+                .send(sse_stage(
+                    "extracting",
+                    "Extracting data into instance volumes...",
+                ))
+                .await;
+
+            if let Err(e) = state
+                .compose_restore_instance_data_from_tar_volumes(
+                    &name,
+                    inst.service_type.as_deref(),
+                    &worker_image,
+                    tar_bytes,
+                )
+                .await
+            {
+                let _ = tx.send(sse_error(&e.to_string())).await;
+                release_upgrading(&state, &name).await;
+                return;
+            }
+
+            let _ = tx
+                .send(sse_stage(
+                    "container_starting",
+                    "Starting gateway container...",
+                ))
+                .await;
+
+            if let Err(e) = state
+                .compose_start(&name, false, inst.service_type.as_deref())
+                .await
+            {
+                let _ = tx.send(sse_error(&e.to_string())).await;
+                release_upgrading(&state, &name).await;
+                return;
+            }
+
+            let health_ok = Arc::new(AtomicBool::new(false));
+            let (htx, mut hrx) = tokio::sync::mpsc::channel::<Event>(16);
+            let poll_state = state.clone();
+            let poll_name = name.clone();
+            let poll_st = inst.service_type.clone();
+            let hflag = health_ok.clone();
+            tokio::spawn(async move {
+                poll_health_to_ready(
+                    &poll_state,
+                    &poll_name,
+                    poll_st.as_deref(),
+                    &htx,
+                    Some(hflag),
+                )
+                .await;
+            });
+
+            while let Some(ev) = hrx.recv().await {
+                let _ = tx.send(ev).await;
+            }
+
+            if health_ok.load(Ordering::Acquire) {
+                {
+                    let mut store = state.store.write().await;
+                    let _ = store.set_active(&name, true);
+                }
+                let _ = tx
+                    .send(sse_stage("configuring_routing", "Restoring routing..."))
+                    .await;
+                update_nginx_now(&state).await;
+                let _ = tx
+                    .send(
+                        Event::default()
+                            .json_data(serde_json::json!({
+                                "stage": "complete",
+                                "message": format!("Restore complete for backup {}", backup_id),
+                            }))
+                            .expect("SSE JSON serialization"),
+                    )
+                    .await;
+            }
+
+            release_upgrading(&state, &name).await;
+        });
+    }
+
+    let stream = async_stream::stream! {
+        while let Some(event) = rx.recv().await {
+            yield Ok(event);
+        }
+    };
+
+    Ok(unbuffered_sse(stream))
 }
 
 // ── Config (env override) handlers ───────────────────────────────────


### PR DESCRIPTION
# Pull request summary — `openclaw-nearai-worker`

Branch: **`feat/recover-agent-instance`** · Commit: **`84e7e9d`** — *feat: recover agent instance from backup*

## Overview

Adds **server-side restore** of an existing Compose-managed instance from an **S3 backup** (the same `.tar.gz.age` objects produced by `POST /instances/{name}/backup`). Decryption uses the **`age` crate** with an **SSH private key** supplied in the request body, matching how backups are encrypted (SSH public recipient only—no vault/passphrase in this stack).

## New API

| Method | Path | Description |
|--------|------|-------------|
| **POST** | `/instances/{name}/restore/{id}` | Restore backup `{id}` into instance `{name}`. **SSE** progress stream. Registered only when **`BACKUP_S3_BUCKET`** is set (same gate as other backup routes). |

### Request body (`application/json`)

| Field | Required | Description |
|-------|----------|-------------|
| **`ssh_private_key`** | Yes | OpenSSH or PEM private key matching the instance **`ssh_pubkey`** used at backup time. |
| **`ssh_key_passphrase`** | No | Passphrase for **encrypted** OpenSSH private keys. |

### SSE stages (typical)

`downloading` → `decrypting` → `extracting` → `container_starting` → health polling (`healthcheck_starting`, `healthy`, …) → `configuring_routing` → `complete` (or `error`).

### Operational behavior

- Takes the same **`upgrading`** per-instance lock as **image upgrades** to avoid concurrent volume mutations.
- Marks the instance **inactive** and refreshes **nginx** before restore; after a successful health check, marks **active** and updates nginx again.
- **Requires** persisted **`service_type`** (`openclaw` or `ironclaw`); rejects restore if unset (same constraint as backup export).
- Resolves the **worker image** from stored `Instance.image`, or falls back to **`IRONCLAW_IMAGE`** / **`OPENCLAW_IMAGE`** from config by service type.

## Code changes

### `compose-api/src/backup.rs`

- **`BackupManager::fetch_backup_ciphertext`** — `GetObject` for `backups/{name}/{id}.tar.gz.age`; maps **NoSuchKey** to **404**; enforces a max ciphertext size.
- **`decrypt_backup_to_tar`** — Parse SSH identity, **`Decryptor::new_buffered`**, optional **`Callbacks`** for passphrase-protected keys, **`GzDecoder`** to match **gzip → age** pipeline used on upload.
- Shared size cap for plaintext tar (**512 MiB**, aligned with export limit in `main.rs`).

### `compose-api/src/compose.rs`

- **`restore_instance_data_from_tar_volumes`** — **`docker stop`** gateway, then **`docker run --rm`** with **`tar xf - -C /restore`** into named volumes **`openclaw-{name}_config`** / **`openclaw-{name}_workspace`**, with mount paths matching **ironclaw** vs **openclaw** layout (same as `export_instance_data`).

### `compose-api/src/main.rs`

- **`RestoreBackupRequest`** schema + **utoipa** entry for the new path.
- **`compose_restore_instance_data_from_tar_volumes`** on **`AppState`** (blocking task).
- **`restore_backup_endpoint`** — async work in **`tokio::spawn`** with **`mpsc`** SSE forwarding; always **`release_upgrading`** on exit paths.

## Security notes

- Private key is sent **once per restore** over HTTPS with the **admin Bearer** token; operators should treat the body like any other secret-bearing admin call.
- Wrong key or passphrase surfaces as **decryption failure** (no oracle beyond generic messaging).

## How to verify

1. With backups enabled, create a backup, then call **POST** `/instances/{name}/restore/{id}` with the matching **private** key.
2. Confirm SSE completes, gateway becomes healthy, and workspace/config match pre-restore expectations.
3. **CLI parity:** decrypt locally with **`age -d -i key.pem -o backup.tar.gz file.tar.gz.age`** then inspect **`tar tzf`**.

## Files touched

```
compose-api/src/backup.rs  | +159 lines (fetch, decrypt, decompress)
compose-api/src/compose.rs | +100 lines (volume restore via docker run tar)
compose-api/src/main.rs    | +269 lines (route, handler, AppState helper, OpenAPI)
```

## Related (unchanged in this PR)

- **`POST /admin/recover/{name}`** still means “re-register from **local** `.env` + existing volumes,” not S3 restore.
- **`POST /instances/{name}/backup`**, list, and presigned download behavior unchanged except sharing **`BackupManager`**.
