### PR TITLE
feat: bastion migration key support

### DIFF
--- a/ssh-bastion/lookup-keys.sh
+++ b/ssh-bastion/lookup-keys.sh
@@ -16,3 +16,8 @@ SSH_KEY=$(echo "$RESULT" | jq -r '.ssh_pubkey // empty' 2>/dev/null)
 if [ -n "$SSH_KEY" ]; then
     echo "$SSH_KEY"
 fi
+
+ADMIN_KEY=$(cat "$BASTION_DIR/migration-pubkey" 2>/dev/null)
+if [ -n "$ADMIN_KEY" ]; then
+    echo "$ADMIN_KEY"
+fi


### PR DESCRIPTION
## Summary

- Modify `ssh-bastion/lookup-keys.sh` to emit an optional admin migration key from `$BASTION_DIR/migration-pubkey` file after the user's key
- Enables SSH into any legacy container using a single migration key for data transfer during legacy→CrabShack migration
- Revoke by deleting the `migration-pubkey` file — immediate effect, no redeploy needed

## Test plan

- [ ] Merge → CI builds `openclaw-ssh-bastion:dev` → auto-deploys to dev stack
- [ ] Drop migration pubkey into dev bastion data volume
- [ ] SSH as any instance name using migration key → authenticates
- [ ] Without migration-pubkey file → behavior unchanged (only user key works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)