### PR TITLE
Enhance backup endpoint for legacy-to-CrabShack migration

### DIFF
--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -183,6 +183,8 @@ fn encrypt_with_ssh_pubkey(data: &[u8], ssh_pubkey: &str) -> Result<Vec<u8>, Api
 /// Encrypt data using an age recipient string.
 /// Tries parsing as X25519 ("age1...") first, then falls back to SSH pubkey.
 fn encrypt_with_recipient(data: &[u8], recipient_str: &str) -> Result<Vec<u8>, ApiError> {
+    let recipient_str = recipient_str.trim();
+
     // Try X25519 first (age native keys start with "age1")
     if let Ok(recipient) = recipient_str.parse::<age::x25519::Recipient>() {
         return encrypt_with_boxed_recipient(data, Box::new(recipient));

--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -10,6 +10,8 @@ use serde::Serialize;
 
 use crate::error::ApiError;
 
+const DEFAULT_PRESIGNED_URL_EXPIRY_SECS: u64 = 3600;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct BackupInfo {
     pub id: String,
@@ -45,12 +47,16 @@ impl BackupManager {
     }
 
     /// Create an encrypted backup from pre-exported instance data.
-    /// tar_bytes → gzip → age-encrypt with SSH pubkey → upload to S3.
+    /// tar_bytes → gzip → age-encrypt → upload to S3.
+    ///
+    /// When `age_recipient` is provided, encrypts to that key (X25519 "age1..." or SSH pubkey).
+    /// Otherwise falls back to the instance's SSH pubkey.
     pub async fn create_backup(
         &self,
         instance_name: &str,
         ssh_pubkey: &str,
         tar_bytes: Vec<u8>,
+        age_recipient: Option<&str>,
     ) -> Result<BackupInfo, ApiError> {
         if tar_bytes.is_empty() {
             return Err(ApiError::Internal(
@@ -67,8 +73,11 @@ impl BackupManager {
             .finish()
             .map_err(|e| ApiError::Internal(format!("gzip finish failed: {}", e)))?;
 
-        // Encrypt with age using SSH public key
-        let encrypted = encrypt_with_ssh_pubkey(&gz_bytes, ssh_pubkey)?;
+        // Encrypt with age: prefer explicit age_recipient, fall back to SSH pubkey
+        let encrypted = match age_recipient {
+            Some(recipient_str) => encrypt_with_recipient(&gz_bytes, recipient_str)?,
+            None => encrypt_with_ssh_pubkey(&gz_bytes, ssh_pubkey)?,
+        };
 
         // Upload to S3
         let now = Utc::now();
@@ -134,12 +143,15 @@ impl BackupManager {
         Ok(backups)
     }
 
-    /// Generate a presigned download URL for a backup (~1h expiry).
+    /// Generate a presigned download URL for a backup.
+    /// `expiry_secs` defaults to 3600 (1 hour) when None.
     pub async fn download_url(
         &self,
         instance_name: &str,
         backup_id: &str,
+        expiry_secs: Option<u64>,
     ) -> Result<String, ApiError> {
+        let expiry = expiry_secs.unwrap_or(DEFAULT_PRESIGNED_URL_EXPIRY_SECS);
         let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
 
         let presigned = self
@@ -149,7 +161,7 @@ impl BackupManager {
             .key(&key)
             .presigned(
                 PresigningConfig::builder()
-                    .expires_in(Duration::from_secs(3600))
+                    .expires_in(Duration::from_secs(expiry))
                     .build()
                     .map_err(|e| ApiError::Internal(format!("presign config error: {}", e)))?,
             )
@@ -165,7 +177,32 @@ fn encrypt_with_ssh_pubkey(data: &[u8], ssh_pubkey: &str) -> Result<Vec<u8>, Api
     let recipient = age::ssh::Recipient::from_str(ssh_pubkey)
         .map_err(|e| ApiError::Internal(format!("invalid SSH public key: {:?}", e)))?;
 
-    let recipient: Box<dyn age::Recipient + Send> = Box::new(recipient);
+    encrypt_with_boxed_recipient(data, Box::new(recipient))
+}
+
+/// Encrypt data using an age recipient string.
+/// Tries parsing as X25519 ("age1...") first, then falls back to SSH pubkey.
+fn encrypt_with_recipient(data: &[u8], recipient_str: &str) -> Result<Vec<u8>, ApiError> {
+    // Try X25519 first (age native keys start with "age1")
+    if let Ok(recipient) = recipient_str.parse::<age::x25519::Recipient>() {
+        return encrypt_with_boxed_recipient(data, Box::new(recipient));
+    }
+
+    // Fall back to SSH pubkey
+    if let Ok(recipient) = age::ssh::Recipient::from_str(recipient_str) {
+        return encrypt_with_boxed_recipient(data, Box::new(recipient));
+    }
+
+    Err(ApiError::BadRequest(format!(
+        "age_recipient is neither a valid X25519 recipient (age1...) nor an SSH public key"
+    )))
+}
+
+/// Encrypt data with a boxed age::Recipient.
+fn encrypt_with_boxed_recipient(
+    data: &[u8],
+    recipient: Box<dyn age::Recipient + Send>,
+) -> Result<Vec<u8>, ApiError> {
     let encryptor =
         age::Encryptor::with_recipients(std::iter::once(&*recipient as &dyn age::Recipient))
             .map_err(|e| ApiError::Internal(format!("encryptor init failed: {:?}", e)))?;

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -775,40 +775,45 @@ impl ComposeManager {
     /// Uses `docker exec tar` to capture both directories relative to `/home/agent/`.
     /// `service_type` must match the instance (ironclaw vs openclaw); if it is wrong,
     /// the wrong dirs are archived and restore will create the wrong paths in the new container.
+    ///
+    /// When `full_export` is true, tars ALL of `/home/agent/` instead of specific subdirs.
+    /// This is used for migration to capture the complete home directory.
     pub fn export_instance_data(
         &self,
         name: &str,
         service_type: Option<&str>,
+        full_export: bool,
     ) -> Result<Vec<u8>, ApiError> {
         let container = format!("openclaw-{}-gateway-1", name);
-        let (config_dir, workspace_dir) = match service_type {
-            Some("ironclaw") => (".ironclaw", "workspace"),
-            Some("openclaw") => (".openclaw", "openclaw"),
-            None => {
-                return Err(ApiError::Internal(format!(
-                    "Cannot export instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
-                    name
-                )));
-            }
-            Some(other) => {
-                return Err(ApiError::Internal(format!(
-                    "Unknown service_type for export: '{}' (instance '{}')",
-                    other, name
-                )));
-            }
-        };
+
+        let mut args = vec!["exec", &container, "tar", "cf", "-", "-C", "/home/agent"];
+
+        if full_export {
+            // Export everything in /home/agent
+            args.push(".");
+        } else {
+            let (config_dir, workspace_dir) = match service_type {
+                Some("ironclaw") => (".ironclaw", "workspace"),
+                Some("openclaw") => (".openclaw", "openclaw"),
+                None => {
+                    return Err(ApiError::Internal(format!(
+                        "Cannot export instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
+                        name
+                    )));
+                }
+                Some(other) => {
+                    return Err(ApiError::Internal(format!(
+                        "Unknown service_type for export: '{}' (instance '{}')",
+                        other, name
+                    )));
+                }
+            };
+            args.push(config_dir);
+            args.push(workspace_dir);
+        }
+
         let output = Command::new("docker")
-            .args([
-                "exec",
-                &container,
-                "tar",
-                "cf",
-                "-",
-                "-C",
-                "/home/agent",
-                config_dir,
-                workspace_dir,
-            ])
+            .args(&args)
             .output()
             .map_err(|e| ApiError::Internal(format!("Failed to run docker exec tar: {}", e)))?;
 

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -1832,6 +1832,9 @@ struct InstanceResponse {
     nearai_api_url: Option<String>,
     image: String,
     image_digest: Option<String>,
+    mem_limit: Option<String>,
+    cpus: Option<String>,
+    storage_size: Option<String>,
     status: String,
     created_at: String,
 }
@@ -2473,6 +2476,9 @@ async fn get_instance(
                 nearai_api_url: inst.nearai_api_url,
                 image,
                 image_digest: inst.image_digest.clone(),
+                mem_limit: inst.mem_limit,
+                cpus: inst.cpus,
+                storage_size: inst.storage_size,
                 status,
                 created_at: inst.created_at.to_rfc3339(),
             }))
@@ -2534,6 +2540,9 @@ async fn list_instances(
                 nearai_api_url: inst.nearai_api_url,
                 image,
                 image_digest: inst.image_digest,
+                mem_limit: inst.mem_limit,
+                cpus: inst.cpus,
+                storage_size: inst.storage_size,
                 status,
                 created_at: inst.created_at.to_rfc3339(),
             }
@@ -3198,6 +3207,7 @@ async fn create_backup_endpoint(
         match result {
             Ok(info) => {
                 yield Ok(sse_stage("uploading", "Encrypted backup uploaded to S3"));
+                let download_url = backup_mgr.download_url(&name, &info.id, expiry_secs).await.ok();
                 yield Ok(Event::default()
                     .json_data(serde_json::json!({
                         "stage": "complete",
@@ -3206,7 +3216,7 @@ async fn create_backup_endpoint(
                             "id": info.id,
                             "timestamp": info.timestamp.to_rfc3339(),
                             "size_bytes": info.size_bytes,
-                            "expiry_secs": expiry_secs.unwrap_or(3600),
+                            "download_url": download_url,
                         }
                     }))
                     .expect("SSE JSON serialization"));

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -330,12 +330,13 @@ impl AppState {
         &self,
         name: &str,
         service_type: Option<&str>,
+        full_export: bool,
     ) -> Result<Vec<u8>, ApiError> {
         let compose = self.compose.clone();
         let name = name.to_string();
         let service_type = service_type.map(|s| s.to_string());
         tokio::task::spawn_blocking(move || {
-            compose.export_instance_data(&name, service_type.as_deref())
+            compose.export_instance_data(&name, service_type.as_deref(), full_export)
         })
         .await
         .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
@@ -1827,6 +1828,8 @@ struct InstanceResponse {
     ssh_port: u16,
     ssh_command: String,
     ssh_pubkey: String,
+    nearai_api_key: String,
+    nearai_api_url: Option<String>,
     image: String,
     image_digest: Option<String>,
     status: String,
@@ -2466,6 +2469,8 @@ async fn get_instance(
                 ssh_port: inst.ssh_port,
                 ssh_command,
                 ssh_pubkey: inst.ssh_pubkey,
+                nearai_api_key: inst.nearai_api_key,
+                nearai_api_url: inst.nearai_api_url,
                 image,
                 image_digest: inst.image_digest.clone(),
                 status,
@@ -2525,6 +2530,8 @@ async fn list_instances(
                 ssh_port: inst.ssh_port,
                 ssh_command,
                 ssh_pubkey: inst.ssh_pubkey,
+                nearai_api_key: inst.nearai_api_key,
+                nearai_api_url: inst.nearai_api_url,
                 image,
                 image_digest: inst.image_digest,
                 status,
@@ -2705,7 +2712,7 @@ async fn restart_instance(
                     .send(sse_stage("exporting", "Exporting workspace and config..."))
                     .await;
 
-                let tar_bytes = match state.compose_export_instance_data(&name, Some(stype)).await {
+                let tar_bytes = match state.compose_export_instance_data(&name, Some(stype), false).await {
                     Ok(bytes) => {
                         if bytes.len() > MAX_EXPORT_BYTES {
                             let _ = tx
@@ -3126,6 +3133,20 @@ async fn tdx_attestation(
 
 // ── Backup handlers ──────────────────────────────────────────────────
 
+/// Optional request body for the backup endpoint.
+/// All fields are optional for backward compatibility — an empty or missing body
+/// uses the instance's SSH pubkey for encryption, 3600s URL expiry, and standard subdirs.
+#[derive(Deserialize, Default, utoipa::ToSchema)]
+struct BackupRequest {
+    /// X25519 recipient ("age1...") or SSH pubkey to encrypt the backup to.
+    /// When absent, uses the instance's SSH pubkey.
+    age_recipient: Option<String>,
+    /// Presigned download URL duration in seconds (default: 3600).
+    expiry_secs: Option<u64>,
+    /// When true, tar all of /home/agent instead of specific subdirs.
+    full_export: Option<bool>,
+}
+
 #[utoipa::path(post, path = "/instances/{name}/backup", tag = "Backups",
     params(("name" = String, Path, description = "Instance name")),
     security(("bearer_auth" = [])),
@@ -3140,12 +3161,18 @@ async fn create_backup_endpoint(
     _auth: AdminAuth,
     State(state): State<AppState>,
     Path(name): Path<String>,
+    body: Option<Json<BackupRequest>>,
 ) -> Result<impl IntoResponse, ApiError> {
     let backup_mgr = state
         .backup
         .as_ref()
         .ok_or_else(|| ApiError::NotImplemented("Backup not configured".into()))?
         .clone();
+
+    let req = body.map(|Json(b)| b).unwrap_or_default();
+    let age_recipient = req.age_recipient;
+    let expiry_secs = req.expiry_secs;
+    let full_export = req.full_export.unwrap_or(false);
 
     let inst = {
         let store = state.store.read().await;
@@ -3156,7 +3183,7 @@ async fn create_backup_endpoint(
     let stream = async_stream::stream! {
         yield Ok(sse_stage("encrypting", "Exporting and encrypting workspace..."));
 
-        let tar_bytes = match state.compose_export_instance_data(&name, inst.service_type.as_deref()).await {
+        let tar_bytes = match state.compose_export_instance_data(&name, inst.service_type.as_deref(), full_export).await {
             Ok(bytes) => bytes,
             Err(e) => {
                 yield Ok(sse_error(&format!("Backup failed: {}", e)));
@@ -3165,7 +3192,7 @@ async fn create_backup_endpoint(
         };
 
         let result = backup_mgr
-            .create_backup(&name, &inst.ssh_pubkey, tar_bytes)
+            .create_backup(&name, &inst.ssh_pubkey, tar_bytes, age_recipient.as_deref())
             .await;
 
         match result {
@@ -3179,6 +3206,7 @@ async fn create_backup_endpoint(
                             "id": info.id,
                             "timestamp": info.timestamp.to_rfc3339(),
                             "size_bytes": info.size_bytes,
+                            "expiry_secs": expiry_secs.unwrap_or(3600),
                         }
                     }))
                     .expect("SSE JSON serialization"));
@@ -3261,7 +3289,7 @@ async fn download_backup_endpoint(
         }
     }
 
-    let url = backup_mgr.download_url(&name, &id).await?;
+    let url = backup_mgr.download_url(&name, &id, None).await?;
 
     Ok(Json(BackupDownloadResponse {
         url,
@@ -4590,7 +4618,7 @@ async fn background_sync_loop(state: AppState) {
                     }
                     tracing::info!("Scheduled backup for instance: {}", inst.name);
                     let tar_bytes = match state
-                        .compose_export_instance_data(&inst.name, inst.service_type.as_deref())
+                        .compose_export_instance_data(&inst.name, inst.service_type.as_deref(), false)
                         .await
                     {
                         Ok(bytes) => bytes,
@@ -4604,7 +4632,7 @@ async fn background_sync_loop(state: AppState) {
                         }
                     };
                     match backup_mgr
-                        .create_backup(&inst.name, &inst.ssh_pubkey, tar_bytes)
+                        .create_backup(&inst.name, &inst.ssh_pubkey, tar_bytes, None)
                         .await
                     {
                         Ok(info) => {

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -3181,6 +3181,13 @@ async fn create_backup_endpoint(
     let req = body.map(|Json(b)| b).unwrap_or_default();
     let age_recipient = req.age_recipient;
     let expiry_secs = req.expiry_secs;
+    if let Some(secs) = expiry_secs {
+        if secs < 1 || secs > 604800 {
+            return Err(ApiError::BadRequest(
+                "expiry_secs must be between 1 and 604800 (S3 presigned URL limit)".into(),
+            ));
+        }
+    }
     let full_export = req.full_export.unwrap_or(false);
 
     let inst = {
@@ -3207,7 +3214,13 @@ async fn create_backup_endpoint(
         match result {
             Ok(info) => {
                 yield Ok(sse_stage("uploading", "Encrypted backup uploaded to S3"));
-                let download_url = backup_mgr.download_url(&name, &info.id, expiry_secs).await.ok();
+                let download_url = match backup_mgr.download_url(&name, &info.id, expiry_secs).await {
+                    Ok(url) => Some(url),
+                    Err(e) => {
+                        tracing::error!("Failed to generate download URL for backup {}: {}", info.id, e);
+                        None
+                    }
+                };
                 yield Ok(Event::default()
                     .json_data(serde_json::json!({
                         "stage": "complete",

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -3158,6 +3158,7 @@ struct BackupRequest {
 
 #[utoipa::path(post, path = "/instances/{name}/backup", tag = "Backups",
     params(("name" = String, Path, description = "Instance name")),
+    request_body(content = Option<BackupRequest>, description = "Optional backup parameters (age recipient, expiry, full export)"),
     security(("bearer_auth" = [])),
     responses(
         (status = 200, description = "SSE stream of backup progress", content_type = "text/event-stream", body = SseEvent),


### PR DESCRIPTION
One of three legacy TEE to crabsack migration PRs. See also https://github.com/nearai/chat-api/pull/289 https://github.com/nearai/openclaw-nearai-worker/pull/225

Here we add support encryption using the backup passphrase which will be compatible with crabshack decryption.

## Summary

- Backup endpoint `POST /instances/{name}/backup` now accepts optional JSON body with `age_recipient` (X25519 or SSH key), `expiry_secs`, and `full_export` parameters
- Returns presigned `download_url` in SSE "complete" event (callers don't need a second API call)
- `InstanceResponse` now includes `nearai_api_key`, `nearai_api_url`, `mem_limit`, `cpus`, `storage_size` for migration tooling
- `export_instance_data()` supports `full_export` mode (tars all of `/home/agent/` instead of specific subdirs)
- X25519 recipient support: tries `age::x25519::Recipient` first, falls back to `age::ssh::Recipient`
- All changes are backward compatible — empty/missing body preserves existing behavior

## Test plan

- [x] 110 existing tests pass, 0 regressions
- [x] Compilation clean
- [ ] Deploy to dev, verify backup with age_recipient + full_export
- [ ] Verify existing backup flow unchanged (no body)

Part of the legacy → CrabShack migration (plan: `reports/bzj-migration-plan-v4.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)