### PR TITLE
Reduce SSE keepalive interval from 15s to 5s

### DIFF
--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -2061,7 +2061,7 @@ fn unbuffered_sse(
     let headers = [("X-Accel-Buffering", "no"), ("Cache-Control", "no-cache")];
     let sse = Sse::new(stream).keep_alive(
         axum::response::sse::KeepAlive::new()
-            .interval(std::time::Duration::from_secs(15))
+            .interval(std::time::Duration::from_secs(5))
             .text("keep-alive"),
     );
     (headers, sse)


### PR DESCRIPTION
## Summary
- SSE keepalive interval reduced from 15s to 5s in `unbuffered_sse()`

## Context
The backup endpoint's SSE stream goes silent during `docker exec tar` + S3 upload (up to 60s+ for large instances). With a 15s keepalive, tokio timer jitter under `spawn_blocking` load delays the first keepalive to ~43s — exceeding the chat-api migration client's 30s chunk timeout.

Observed in staging: backup for a 298MB instance takes ~52s. First keepalive arrived at 43.5s instead of 15s. Chat-api timed out at 30s every time.

5s interval ensures keepalives arrive well within any reasonable client timeout.

## Test plan
- [ ] Deploy to staging openclaw-dev
- [ ] Trigger migration backup via chat-api — should no longer timeout
- [ ] Verify scheduled backups still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)