### PR TITLE
fix: expose extra_env in instance API responses

### DIFF
--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -9,6 +9,37 @@ use crate::store::Instance;
 /// Default NEAR AI Cloud API URL used when not specified per-instance.
 pub const DEFAULT_NEARAI_API_URL: &str = "https://cloud-api.near.ai/v1";
 
+/// Env vars managed by compose-api (written by ensure_env_file / up).
+/// Anything NOT in this list is considered user-supplied "extra_env".
+const CORE_ENV_KEYS: &[&str] = &[
+    "NEARAI_API_KEY",
+    "NEARAI_API_URL",
+    "OPENCLAW_GATEWAY_TOKEN",
+    "GATEWAY_AUTH_TOKEN",
+    "ENGINE_V2",
+    "GATEWAY_PORT",
+    "SSH_PORT",
+    "SSH_PUBKEY",
+    "BASTION_SSH_PUBKEY",
+    "OPENCLAW_IMAGE",
+    "SERVICE_TYPE",
+    "WORKER_NETWORK",
+    "MEM_LIMIT",
+    "CPUS",
+    "STORAGE_SIZE",
+    "OPENCLAW_DOMAIN",
+    "OPENCLAW_INSTANCE_NAME",
+    "IRONCLAW_DOMAIN",
+    "IRONCLAW_INSTANCE_NAME",
+    "GOOGLE_OAUTH_CLIENT_ID",
+    "IRONCLAW_OAUTH_EXCHANGE_URL",
+];
+
+/// System/Docker env vars to exclude when collecting extra_env from a container.
+const SYSTEM_ENV_KEYS: &[&str] = &[
+    "PATH", "HOME", "HOSTNAME", "LANG", "LC_ALL", "TERM", "SHLVL", "PWD", "OLDPWD", "USER", "SHELL",
+];
+
 /// Insert OAuth-related env vars into the given map.
 /// Shared by `up()` and `ensure_env_file()` to avoid duplication.
 fn insert_oauth_env_vars(
@@ -277,36 +308,9 @@ impl ComposeManager {
             )
         });
 
-        // Collect extra env vars: anything not in the core set written by
-        // ensure_env_file / up(). These include user-configured vars like
-        // CHANNEL_RELAY_URL, CHANNEL_RELAY_API_KEY, etc.
-        const CORE_KEYS: &[&str] = &[
-            "NEARAI_API_KEY",
-            "NEARAI_API_URL",
-            "OPENCLAW_GATEWAY_TOKEN",
-            "GATEWAY_AUTH_TOKEN",
-            "ENGINE_V2",
-            "GATEWAY_PORT",
-            "SSH_PORT",
-            "SSH_PUBKEY",
-            "BASTION_SSH_PUBKEY",
-            "OPENCLAW_IMAGE",
-            "SERVICE_TYPE",
-            "WORKER_NETWORK",
-            "MEM_LIMIT",
-            "CPUS",
-            "STORAGE_SIZE",
-            // OAuth vars written by insert_oauth_env_vars
-            "OPENCLAW_DOMAIN",
-            "OPENCLAW_INSTANCE_NAME",
-            "IRONCLAW_DOMAIN",
-            "IRONCLAW_INSTANCE_NAME",
-            "GOOGLE_OAUTH_CLIENT_ID",
-            "IRONCLAW_OAUTH_EXCHANGE_URL",
-        ];
         let extra: HashMap<String, String> = vars
             .iter()
-            .filter(|(k, _)| !CORE_KEYS.contains(&k.as_str()))
+            .filter(|(k, _)| !CORE_ENV_KEYS.contains(&k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         let extra_env = if extra.is_empty() { None } else { Some(extra) };
@@ -1073,47 +1077,11 @@ impl ComposeManager {
         // Resolve image digest from .Image → RepoDigests
         let image_digest = self.resolve_image_digest(name);
 
-        // Collect extra env vars: anything not in the core or system sets.
-        // Mirrors the CORE_KEYS logic in recover_from_env.
-        const KNOWN_KEYS: &[&str] = &[
-            // Core keys (same as recover_from_env)
-            "NEARAI_API_KEY",
-            "NEARAI_API_URL",
-            "OPENCLAW_GATEWAY_TOKEN",
-            "GATEWAY_AUTH_TOKEN",
-            "ENGINE_V2",
-            "GATEWAY_PORT",
-            "SSH_PORT",
-            "SSH_PUBKEY",
-            "BASTION_SSH_PUBKEY",
-            "OPENCLAW_IMAGE",
-            "SERVICE_TYPE",
-            "WORKER_NETWORK",
-            "MEM_LIMIT",
-            "CPUS",
-            "STORAGE_SIZE",
-            "OPENCLAW_DOMAIN",
-            "OPENCLAW_INSTANCE_NAME",
-            "IRONCLAW_DOMAIN",
-            "IRONCLAW_INSTANCE_NAME",
-            "GOOGLE_OAUTH_CLIENT_ID",
-            "IRONCLAW_OAUTH_EXCHANGE_URL",
-            // System/Docker env vars
-            "PATH",
-            "HOME",
-            "HOSTNAME",
-            "LANG",
-            "LC_ALL",
-            "TERM",
-            "SHLVL",
-            "PWD",
-            "OLDPWD",
-            "USER",
-            "SHELL",
-        ];
         let extra: HashMap<String, String> = env_map
             .iter()
-            .filter(|(k, _)| !KNOWN_KEYS.contains(&k.as_str()))
+            .filter(|(k, _)| {
+                !CORE_ENV_KEYS.contains(&k.as_str()) && !SYSTEM_ENV_KEYS.contains(&k.as_str())
+            })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         let extra_env = if extra.is_empty() { None } else { Some(extra) };

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -1073,6 +1073,51 @@ impl ComposeManager {
         // Resolve image digest from .Image → RepoDigests
         let image_digest = self.resolve_image_digest(name);
 
+        // Collect extra env vars: anything not in the core or system sets.
+        // Mirrors the CORE_KEYS logic in recover_from_env.
+        const KNOWN_KEYS: &[&str] = &[
+            // Core keys (same as recover_from_env)
+            "NEARAI_API_KEY",
+            "NEARAI_API_URL",
+            "OPENCLAW_GATEWAY_TOKEN",
+            "GATEWAY_AUTH_TOKEN",
+            "ENGINE_V2",
+            "GATEWAY_PORT",
+            "SSH_PORT",
+            "SSH_PUBKEY",
+            "BASTION_SSH_PUBKEY",
+            "OPENCLAW_IMAGE",
+            "SERVICE_TYPE",
+            "WORKER_NETWORK",
+            "MEM_LIMIT",
+            "CPUS",
+            "STORAGE_SIZE",
+            "OPENCLAW_DOMAIN",
+            "OPENCLAW_INSTANCE_NAME",
+            "IRONCLAW_DOMAIN",
+            "IRONCLAW_INSTANCE_NAME",
+            "GOOGLE_OAUTH_CLIENT_ID",
+            "IRONCLAW_OAUTH_EXCHANGE_URL",
+            // System/Docker env vars
+            "PATH",
+            "HOME",
+            "HOSTNAME",
+            "LANG",
+            "LC_ALL",
+            "TERM",
+            "SHLVL",
+            "PWD",
+            "OLDPWD",
+            "USER",
+            "SHELL",
+        ];
+        let extra: HashMap<String, String> = env_map
+            .iter()
+            .filter(|(k, _)| !KNOWN_KEYS.contains(&k.as_str()))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        let extra_env = if extra.is_empty() { None } else { Some(extra) };
+
         Ok(Instance {
             name: name.to_string(),
             token,
@@ -1089,7 +1134,7 @@ impl ComposeManager {
             mem_limit: None,
             cpus: None,
             storage_size: None,
-            extra_env: None,
+            extra_env,
         })
     }
 

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -1077,7 +1077,7 @@ impl ComposeManager {
         // Resolve image digest from .Image → RepoDigests
         let image_digest = self.resolve_image_digest(name);
 
-        let extra: HashMap<String, String> = env_map
+        let mut extra: HashMap<String, String> = env_map
             .iter()
             .filter(|(k, v)| {
                 !v.is_empty()
@@ -1086,6 +1086,16 @@ impl ComposeManager {
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+
+        // ironclaw generates SECRETS_MASTER_KEY at runtime (entrypoint.sh writes it to
+        // .master_key on disk). It's not in Config.Env, so read it from the container.
+        if service_type.as_deref() == Some("ironclaw") && !extra.contains_key("SECRETS_MASTER_KEY")
+        {
+            if let Some(key) = self.read_master_key_from_container(container_name) {
+                extra.insert("SECRETS_MASTER_KEY".to_string(), key);
+            }
+        }
+
         let extra_env = if extra.is_empty() { None } else { Some(extra) };
 
         Ok(Instance {
@@ -1121,6 +1131,38 @@ impl ComposeManager {
             .as_str()?
             .parse()
             .ok()
+    }
+
+    /// Read SECRETS_MASTER_KEY from an ironclaw container's persisted .master_key file.
+    /// Returns None if the file doesn't exist or the value is invalid.
+    fn read_master_key_from_container(&self, container_name: &str) -> Option<String> {
+        let output = Command::new("docker")
+            .args([
+                "exec",
+                container_name,
+                "cat",
+                "/home/agent/.ironclaw/.master_key",
+            ])
+            .output()
+            .ok()?;
+
+        if !output.status.success() {
+            return None;
+        }
+
+        let key = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+        // Validate: must be 64 hex chars (32 bytes)
+        if key.len() == 64 && key.chars().all(|c| c.is_ascii_hexdigit()) {
+            Some(key)
+        } else {
+            tracing::warn!(
+                "Container {} has .master_key but it's not valid 64-char hex (len={})",
+                container_name,
+                key.len()
+            );
+            None
+        }
     }
 
     /// Query the application version from a running container.

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -1156,7 +1156,6 @@ impl ComposeManager {
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Output is typically "ironclaw 0.29.0" or "openclaw 2026.2.15"
         let version = stdout
-            .trim()
             .split_whitespace()
             .last()
             .unwrap_or("")

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -1079,8 +1079,10 @@ impl ComposeManager {
 
         let extra: HashMap<String, String> = env_map
             .iter()
-            .filter(|(k, _)| {
-                !CORE_ENV_KEYS.contains(&k.as_str()) && !SYSTEM_ENV_KEYS.contains(&k.as_str())
+            .filter(|(k, v)| {
+                !v.is_empty()
+                    && !CORE_ENV_KEYS.contains(&k.as_str())
+                    && !SYSTEM_ENV_KEYS.contains(&k.as_str())
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
@@ -1155,11 +1157,7 @@ impl ComposeManager {
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         // Output is typically "ironclaw 0.29.0" or "openclaw 2026.2.15"
-        let version = stdout
-            .split_whitespace()
-            .last()
-            .unwrap_or("")
-            .to_string();
+        let version = stdout.split_whitespace().last().unwrap_or("").to_string();
 
         if version.is_empty() {
             return Err(ApiError::Internal(format!(

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -1153,6 +1153,57 @@ impl ComposeManager {
             .ok()
     }
 
+    /// Query the application version from a running container.
+    /// Runs `ironclaw --version` (or `openclaw --version`) and parses the semver.
+    pub fn query_app_version(
+        &self,
+        name: &str,
+        service_type: Option<&str>,
+    ) -> Result<String, ApiError> {
+        let container = format!("openclaw-{}-gateway-1", name);
+        let binary = match service_type {
+            Some("ironclaw") => "ironclaw",
+            _ => "openclaw",
+        };
+
+        let output = Command::new("docker")
+            .args(["exec", &container, binary, "--version"])
+            .output()
+            .map_err(|e| {
+                ApiError::Internal(format!(
+                    "failed to run docker exec {} --version: {}",
+                    binary, e
+                ))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ApiError::Internal(format!(
+                "{} --version failed: {}",
+                binary,
+                stderr.trim()
+            )));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Output is typically "ironclaw 0.29.0" or "openclaw 2026.2.15"
+        let version = stdout
+            .trim()
+            .split_whitespace()
+            .last()
+            .unwrap_or("")
+            .to_string();
+
+        if version.is_empty() {
+            return Err(ApiError::Internal(format!(
+                "{} --version returned empty output",
+                binary
+            )));
+        }
+
+        Ok(version)
+    }
+
     /// Reconstruct the env file for a discovered instance so that
     /// docker compose lifecycle commands (stop/start/restart) continue to work.
     /// `default_image` should be the correct image for this instance's service type

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -1644,6 +1644,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/instances/{name}/restart", post(restart_instance))
         .route("/instances/{name}/stop", post(stop_instance))
         .route("/instances/{name}/start", post(start_instance))
+        .route("/instances/{name}/version", get(get_instance_version))
         .route("/instances/{name}/attestation", get(instance_attestation))
         .route("/attestation/report", get(tdx_attestation))
         .route("/config", get(get_config))
@@ -2488,6 +2489,40 @@ async fn get_instance(
         }
         None => Err(ApiError::NotFound(format!("Instance '{}' not found", name))),
     }
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+struct AppVersionResponse {
+    version: String,
+}
+
+#[utoipa::path(get, path = "/instances/{name}/version", tag = "Instances",
+    params(("name" = String, Path, description = "Instance name")),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Application version", body = AppVersionResponse),
+        (status = 404, description = "Instance not found", body = ErrorResponse),
+        (status = 500, description = "Failed to query version", body = ErrorResponse),
+    )
+)]
+async fn get_instance_version(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let service_type = {
+        let store = state.store.read().await;
+        store
+            .get(&name)
+            .map(|inst| inst.service_type.clone())
+            .ok_or_else(|| ApiError::NotFound(format!("Instance '{}' not found", name)))?
+    };
+
+    let version = state
+        .compose
+        .query_app_version(&name, service_type.as_deref())?;
+
+    Ok(Json(AppVersionResponse { version }))
 }
 
 #[utoipa::path(get, path = "/instances", tag = "Instances",

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -82,9 +82,11 @@ use store::{Instance, InstanceStore, PortRange};
         oauth_callback_router,
         oauth_exchange,
         oauth_refresh,
+        get_instance_version,
     ),
     components(schemas(
         VersionResponse,
+        AppVersionResponse,
         CreateInstanceRequest,
         RestartInstanceRequest,
         InstanceInfo,
@@ -2518,9 +2520,13 @@ async fn get_instance_version(
             .ok_or_else(|| ApiError::NotFound(format!("Instance '{}' not found", name)))?
     };
 
-    let version = state
-        .compose
-        .query_app_version(&name, service_type.as_deref())?;
+    let compose = state.compose.clone();
+    let name_clone = name.clone();
+    let st = service_type.clone();
+    let version =
+        tokio::task::spawn_blocking(move || compose.query_app_version(&name_clone, st.as_deref()))
+            .await
+            .map_err(|e| ApiError::Internal(format!("task join: {e}")))??;
 
     Ok(Json(AppVersionResponse { version }))
 }

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -26,10 +26,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
 use utoipa_scalar::{Scalar, Servable};
 
+use std::collections::HashMap;
+
 #[cfg(test)]
 use base64::engine::general_purpose::URL_SAFE;
-#[cfg(test)]
-use std::collections::HashMap;
 #[cfg(test)]
 use std::ffi::OsString;
 #[cfg(test)]
@@ -1835,6 +1835,8 @@ struct InstanceResponse {
     mem_limit: Option<String>,
     cpus: Option<String>,
     storage_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_env: Option<HashMap<String, String>>,
     status: String,
     created_at: String,
 }
@@ -2479,6 +2481,7 @@ async fn get_instance(
                 mem_limit: inst.mem_limit,
                 cpus: inst.cpus,
                 storage_size: inst.storage_size,
+                extra_env: inst.extra_env,
                 status,
                 created_at: inst.created_at.to_rfc3339(),
             }))
@@ -2543,6 +2546,7 @@ async fn list_instances(
                 mem_limit: inst.mem_limit,
                 cpus: inst.cpus,
                 storage_size: inst.storage_size,
+                extra_env: inst.extra_env,
                 status,
                 created_at: inst.created_at.to_rfc3339(),
             }
@@ -2721,7 +2725,10 @@ async fn restart_instance(
                     .send(sse_stage("exporting", "Exporting workspace and config..."))
                     .await;
 
-                let tar_bytes = match state.compose_export_instance_data(&name, Some(stype), false).await {
+                let tar_bytes = match state
+                    .compose_export_instance_data(&name, Some(stype), false)
+                    .await
+                {
                     Ok(bytes) => {
                         if bytes.len() > MAX_EXPORT_BYTES {
                             let _ = tx
@@ -4642,7 +4649,11 @@ async fn background_sync_loop(state: AppState) {
                     }
                     tracing::info!("Scheduled backup for instance: {}", inst.name);
                     let tar_bytes = match state
-                        .compose_export_instance_data(&inst.name, inst.service_type.as_deref(), false)
+                        .compose_export_instance_data(
+                            &inst.name,
+                            inst.service_type.as_deref(),
+                            false,
+                        )
                         .await
                     {
                         Ok(bytes) => bytes,


### PR DESCRIPTION
## Context

The automated migration endpoint (`POST /admin/agents/instances/{id}/migrate` in chat-api) fails E2E because:

1. **SECRETS_MASTER_KEY not forwarded** — compose-api's `GET /instances/:name` never returned `extra_env`, so chat-api had no way to read the legacy instance's master encryption key and pass it to CrabShack. Without it, the migrated instance can't decrypt its channel secrets (Telegram bot token, webhook secret, etc.).
2. **NEARAI_MODEL not forwarded** — same issue. Legacy instances may have a user-configured model override that gets lost during migration.
3. **Image version unknown** — legacy `ironclaw-nearai-worker` images have no semver tags on Docker Hub (only `dev`/`latest`). Chat-api needs to know the running ironclaw version to pick a matching `ironclaw-dind` tag for CrabShack.

Root cause: `inspect_container` (the discovery path used on startup) discarded all non-core env vars by hardcoding `extra_env: None`, and `InstanceResponse` didn't include the field.

## Summary

- Extract `CORE_ENV_KEYS` and `SYSTEM_ENV_KEYS` to shared module-level constants
- `inspect_container` now collects extra env vars from the container instead of discarding them
- `InstanceResponse` includes `extra_env` field in both `GET /instances/:name` and `GET /instances`
- New `GET /instances/:name/version` endpoint — runs `ironclaw --version` / `openclaw --version` inside the container and returns the semver

Companion PR: https://github.com/nearai/chat-api/pull/303

## Test plan

- [ ] Deploy to staging compose-api
- [ ] `GET /instances/:name` returns `extra_env` with SECRETS_MASTER_KEY, NEARAI_MODEL when present
- [ ] `GET /instances` list also includes extra_env
- [ ] Instances without extra env vars omit the field (skip_serializing_if)
- [ ] `GET /instances/:name/version` returns correct ironclaw/openclaw version

🤖 Generated with [Claude Code](https://claude.com/claude-code)