### PR TITLE
Run backup pipeline inside worker container to fix OOM on large homes

### DIFF
--- a/compose-api/Cargo.lock
+++ b/compose-api/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,16 +1174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fluent"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,16 +2022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,7 +2127,6 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
- "flate2",
  "futures-util",
  "hex",
  "pem",
@@ -3051,12 +3024,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"

--- a/compose-api/Cargo.toml
+++ b/compose-api/Cargo.toml
@@ -33,7 +33,6 @@ utoipa-scalar = { version = "0.3", features = ["axum"] }
 
 # Backup: encryption + S3 storage
 age = { version = "0.11", features = ["ssh"] }
-flate2 = "1"
 aws-sdk-s3 = "1"
 aws-config = "1"
 

--- a/compose-api/Dockerfile
+++ b/compose-api/Dockerfile
@@ -44,11 +44,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Static age binary — copied into worker containers at backup time so the
-# tar|age|upload pipeline runs entirely inside the container
+# tar|age|upload pipeline runs entirely inside the container. SHA256 pinned
+# (computed from the official v1.2.1 release) to guard against a tampered
+# download installing a malicious binary that runs as root in worker containers.
 ARG AGE_VERSION=v1.2.1
-RUN curl -fsSL "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/age-${AGE_VERSION}-linux-amd64.tar.gz" \
-    | tar xz -C /usr/local/bin --strip-components=1 age/age \
-    && chmod 0755 /usr/local/bin/age
+ARG AGE_SHA256=7df45a6cc87d4da11cc03a539a7470c15b1041ab2b396af088fe9990f7c79d50
+RUN curl -fsSL "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/age-${AGE_VERSION}-linux-amd64.tar.gz" -o /tmp/age.tar.gz \
+    && echo "${AGE_SHA256}  /tmp/age.tar.gz" | sha256sum -c - \
+    && tar xz -C /usr/local/bin --strip-components=1 -f /tmp/age.tar.gz age/age \
+    && chmod 0755 /usr/local/bin/age \
+    && rm /tmp/age.tar.gz
 
 # Copy the binary from builder
 COPY --from=builder /app/target/release/openclaw-compose-api /app/openclaw-compose-api

--- a/compose-api/Dockerfile
+++ b/compose-api/Dockerfile
@@ -43,6 +43,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Static age binary — copied into worker containers at backup time so the
+# tar|age|upload pipeline runs entirely inside the container
+ARG AGE_VERSION=v1.2.1
+RUN curl -fsSL "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/age-${AGE_VERSION}-linux-amd64.tar.gz" \
+    | tar xz -C /usr/local/bin --strip-components=1 age/age \
+    && chmod 0755 /usr/local/bin/age
+
 # Copy the binary from builder
 COPY --from=builder /app/target/release/openclaw-compose-api /app/openclaw-compose-api
 

--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -11,6 +11,17 @@ const DEFAULT_PRESIGNED_URL_EXPIRY_SECS: u64 = 3600;
 /// Presigned PUT URLs only need to outlive a single in-container upload.
 const UPLOAD_URL_EXPIRY_SECS: u64 = 1800;
 
+const BACKUP_KEY_SUFFIX: &str = ".tar.gz.age";
+
+/// S3 object key for an instance backup. Every path that touches a backup
+/// object (presign PUT, verify, list, presign GET) must agree on this layout.
+fn backup_s3_key(instance_name: &str, backup_id: &str) -> String {
+    format!(
+        "backups/{}/{}{}",
+        instance_name, backup_id, BACKUP_KEY_SUFFIX
+    )
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct BackupInfo {
     pub id: String,
@@ -53,7 +64,7 @@ impl BackupManager {
         instance_name: &str,
         backup_id: &str,
     ) -> Result<String, ApiError> {
-        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
+        let key = backup_s3_key(instance_name, backup_id);
 
         let presigned = self
             .s3
@@ -75,7 +86,7 @@ impl BackupManager {
     /// Size of an uploaded backup object, used to verify the in-container
     /// upload actually landed in S3.
     pub async fn object_size(&self, instance_name: &str, backup_id: &str) -> Result<i64, ApiError> {
-        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
+        let key = backup_s3_key(instance_name, backup_id);
 
         let head = self
             .s3
@@ -109,9 +120,8 @@ impl BackupManager {
                     Some(k) => k,
                     None => continue,
                 };
-                // Key format: backups/{name}/{timestamp}.tar.gz.age
                 let filename = key.strip_prefix(&prefix).unwrap_or(key);
-                let id = filename.strip_suffix(".tar.gz.age").unwrap_or(filename);
+                let id = filename.strip_suffix(BACKUP_KEY_SUFFIX).unwrap_or(filename);
 
                 let timestamp = chrono::NaiveDateTime::parse_from_str(id, "%Y%m%dT%H%M%SZ")
                     .ok()
@@ -139,7 +149,7 @@ impl BackupManager {
         expiry_secs: Option<u64>,
     ) -> Result<String, ApiError> {
         let expiry = expiry_secs.unwrap_or(DEFAULT_PRESIGNED_URL_EXPIRY_SECS);
-        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
+        let key = backup_s3_key(instance_name, backup_id);
 
         let presigned = self
             .s3

--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -1,16 +1,15 @@
-use std::io::Write;
 use std::str::FromStr;
 use std::time::Duration;
 
 use aws_sdk_s3::presigning::PresigningConfig;
 use chrono::{DateTime, Utc};
-use flate2::write::GzEncoder;
-use flate2::Compression;
 use serde::Serialize;
 
 use crate::error::ApiError;
 
 const DEFAULT_PRESIGNED_URL_EXPIRY_SECS: u64 = 3600;
+/// Presigned PUT URLs only need to outlive a single in-container upload.
+const UPLOAD_URL_EXPIRY_SECS: u64 = 1800;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct BackupInfo {
@@ -46,60 +45,48 @@ impl BackupManager {
         Some(Self { s3, bucket })
     }
 
-    /// Create an encrypted backup from pre-exported instance data.
-    /// tar_bytes → gzip → age-encrypt → upload to S3.
-    ///
-    /// When `age_recipient` is provided, encrypts to that key (X25519 "age1..." or SSH pubkey).
-    /// Otherwise falls back to the instance's SSH pubkey.
-    pub async fn create_backup(
+    /// Generate a presigned PUT URL so the worker container can upload the
+    /// encrypted backup directly to S3 — archive bytes never pass through
+    /// this process.
+    pub async fn upload_url(
         &self,
         instance_name: &str,
-        ssh_pubkey: &str,
-        tar_bytes: Vec<u8>,
-        age_recipient: Option<&str>,
-    ) -> Result<BackupInfo, ApiError> {
-        if tar_bytes.is_empty() {
-            return Err(ApiError::Internal(
-                "instance data export returned empty data".into(),
-            ));
-        }
+        backup_id: &str,
+    ) -> Result<String, ApiError> {
+        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
 
-        // Gzip compress
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder
-            .write_all(&tar_bytes)
-            .map_err(|e| ApiError::Internal(format!("gzip failed: {}", e)))?;
-        let gz_bytes = encoder
-            .finish()
-            .map_err(|e| ApiError::Internal(format!("gzip finish failed: {}", e)))?;
-
-        // Encrypt with age: prefer explicit age_recipient, fall back to SSH pubkey
-        let encrypted = match age_recipient {
-            Some(recipient_str) => encrypt_with_recipient(&gz_bytes, recipient_str)?,
-            None => encrypt_with_ssh_pubkey(&gz_bytes, ssh_pubkey)?,
-        };
-
-        // Upload to S3
-        let now = Utc::now();
-        let timestamp_str = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let key = format!("backups/{}/{}.tar.gz.age", instance_name, timestamp_str);
-
-        let size = encrypted.len() as i64;
-
-        self.s3
+        let presigned = self
+            .s3
             .put_object()
             .bucket(&self.bucket)
             .key(&key)
-            .body(encrypted.into())
+            .presigned(
+                PresigningConfig::builder()
+                    .expires_in(Duration::from_secs(UPLOAD_URL_EXPIRY_SECS))
+                    .build()
+                    .map_err(|e| ApiError::Internal(format!("presign config error: {}", e)))?,
+            )
+            .await
+            .map_err(|e| ApiError::Internal(format!("presign PUT failed: {}", e)))?;
+
+        Ok(presigned.uri().to_string())
+    }
+
+    /// Size of an uploaded backup object, used to verify the in-container
+    /// upload actually landed in S3.
+    pub async fn object_size(&self, instance_name: &str, backup_id: &str) -> Result<i64, ApiError> {
+        let key = format!("backups/{}/{}.tar.gz.age", instance_name, backup_id);
+
+        let head = self
+            .s3
+            .head_object()
+            .bucket(&self.bucket)
+            .key(&key)
             .send()
             .await
-            .map_err(|e| ApiError::Internal(format!("S3 upload failed: {}", e)))?;
+            .map_err(|e| ApiError::Internal(format!("S3 head_object failed: {}", e)))?;
 
-        Ok(BackupInfo {
-            id: timestamp_str,
-            timestamp: now,
-            size_bytes: size,
-        })
+        Ok(head.content_length().unwrap_or(0))
     }
 
     /// List available backups for an instance.
@@ -172,53 +159,72 @@ impl BackupManager {
     }
 }
 
-/// Encrypt data using an SSH public key via the `age` crate.
-fn encrypt_with_ssh_pubkey(data: &[u8], ssh_pubkey: &str) -> Result<Vec<u8>, ApiError> {
-    let recipient = age::ssh::Recipient::from_str(ssh_pubkey)
-        .map_err(|e| ApiError::Internal(format!("invalid SSH public key: {:?}", e)))?;
-
-    encrypt_with_boxed_recipient(data, Box::new(recipient))
+/// Build the stdin payload that delivers encryption recipients to the
+/// in-container backup script: first line is an X25519 recipient ("age1...")
+/// or empty, remaining lines are SSH pubkeys written to a -R file.
+///
+/// Recipients are validated with the `age` crate before any side effects so
+/// bad input fails as 400, not as a shell error mid-backup. Encryption itself
+/// happens in the worker container via the age CLI.
+pub fn build_backup_stdin(
+    age_recipient: Option<&str>,
+    ssh_pubkey: &str,
+) -> Result<String, ApiError> {
+    match age_recipient.map(str::trim) {
+        Some(r) if r.parse::<age::x25519::Recipient>().is_ok() => Ok(format!("{}\n", r)),
+        Some(r) if age::ssh::Recipient::from_str(r).is_ok() => Ok(format!("\n{}\n", r)),
+        Some(_) => Err(ApiError::BadRequest(
+            "age_recipient is neither a valid X25519 recipient (age1...) nor an SSH public key"
+                .into(),
+        )),
+        None => {
+            let key = ssh_pubkey.trim();
+            age::ssh::Recipient::from_str(key).map_err(|e| {
+                ApiError::Internal(format!(
+                    "instance SSH public key is not age-compatible: {:?}",
+                    e
+                ))
+            })?;
+            Ok(format!("\n{}\n", key))
+        }
+    }
 }
 
-/// Encrypt data using an age recipient string.
-/// Tries parsing as X25519 ("age1...") first, then falls back to SSH pubkey.
-fn encrypt_with_recipient(data: &[u8], recipient_str: &str) -> Result<Vec<u8>, ApiError> {
-    let recipient_str = recipient_str.trim();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    // Try X25519 first (age native keys start with "age1")
-    if let Ok(recipient) = recipient_str.parse::<age::x25519::Recipient>() {
-        return encrypt_with_boxed_recipient(data, Box::new(recipient));
+    const X25519_RECIPIENT: &str = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p";
+    const SSH_PUBKEY: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBPKJsJZLflZQFUP0jXFomSzoJ0dUwbmXrc6J4qDfqyR test";
+
+    #[test]
+    fn test_build_backup_stdin_x25519_recipient() {
+        let payload = build_backup_stdin(Some(X25519_RECIPIENT), SSH_PUBKEY).unwrap();
+        assert_eq!(payload, format!("{}\n", X25519_RECIPIENT));
     }
 
-    // Fall back to SSH pubkey
-    if let Ok(recipient) = age::ssh::Recipient::from_str(recipient_str) {
-        return encrypt_with_boxed_recipient(data, Box::new(recipient));
+    #[test]
+    fn test_build_backup_stdin_ssh_recipient() {
+        let payload = build_backup_stdin(Some(SSH_PUBKEY), "unused").unwrap();
+        assert_eq!(payload, format!("\n{}\n", SSH_PUBKEY));
     }
 
-    Err(ApiError::BadRequest(format!(
-        "age_recipient is neither a valid X25519 recipient (age1...) nor an SSH public key"
-    )))
-}
+    #[test]
+    fn test_build_backup_stdin_invalid_recipient_is_bad_request() {
+        let err = build_backup_stdin(Some("not-a-key"), SSH_PUBKEY).unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+    }
 
-/// Encrypt data with a boxed age::Recipient.
-fn encrypt_with_boxed_recipient(
-    data: &[u8],
-    recipient: Box<dyn age::Recipient + Send>,
-) -> Result<Vec<u8>, ApiError> {
-    let encryptor =
-        age::Encryptor::with_recipients(std::iter::once(&*recipient as &dyn age::Recipient))
-            .map_err(|e| ApiError::Internal(format!("encryptor init failed: {:?}", e)))?;
+    #[test]
+    fn test_build_backup_stdin_falls_back_to_instance_pubkey() {
+        let payload = build_backup_stdin(None, SSH_PUBKEY).unwrap();
+        assert_eq!(payload, format!("\n{}\n", SSH_PUBKEY));
+    }
 
-    let mut encrypted = Vec::new();
-    let mut writer = encryptor
-        .wrap_output(&mut encrypted)
-        .map_err(|e| ApiError::Internal(format!("age wrap_output failed: {}", e)))?;
-    writer
-        .write_all(data)
-        .map_err(|e| ApiError::Internal(format!("age write failed: {}", e)))?;
-    writer
-        .finish()
-        .map_err(|e| ApiError::Internal(format!("age finish failed: {}", e)))?;
-
-    Ok(encrypted)
+    #[test]
+    fn test_build_backup_stdin_rejects_invalid_instance_pubkey() {
+        let err = build_backup_stdin(None, "garbage").unwrap_err();
+        assert!(matches!(err, ApiError::Internal(_)));
+    }
 }

--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -8,8 +8,10 @@ use serde::Serialize;
 use crate::error::ApiError;
 
 const DEFAULT_PRESIGNED_URL_EXPIRY_SECS: u64 = 3600;
-/// Presigned PUT URLs only need to outlive a single in-container upload.
-const UPLOAD_URL_EXPIRY_SECS: u64 = 1800;
+/// Presigned PUT URL lifetime. Must cover tar + encrypt + the whole upload,
+/// since the clock starts when we presign (before the container does any
+/// work). 1h leaves comfortable margin for large/slow backups.
+const UPLOAD_URL_EXPIRY_SECS: u64 = 3600;
 
 const BACKUP_KEY_SUFFIX: &str = ".tar.gz.age";
 

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -846,6 +846,159 @@ impl ComposeManager {
         Ok(output.stdout)
     }
 
+    /// Copy the age binary into an instance's gateway container (to /tmp/age).
+    /// Streamed via docker exec stdin because docker cp does not work reliably
+    /// across storage drivers. Written atomically (tmp + mv) so concurrent
+    /// backups of the same instance cannot observe a partially-written binary.
+    pub fn copy_age_to_container(&self, name: &str) -> Result<(), ApiError> {
+        let container = format!("openclaw-{}-gateway-1", name);
+        let age_path =
+            std::env::var("AGE_BINARY_PATH").unwrap_or_else(|_| "/usr/local/bin/age".to_string());
+        let age_bytes = std::fs::read(&age_path)
+            .map_err(|e| ApiError::Internal(format!("read age binary {}: {}", age_path, e)))?;
+
+        let mut child = docker_command()
+            .args([
+                "exec",
+                "-i",
+                &container,
+                "sh",
+                "-c",
+                "cat > /tmp/.age.tmp && chmod 0755 /tmp/.age.tmp && mv /tmp/.age.tmp /tmp/age",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ApiError::Internal(format!("docker exec spawn (age copy): {}", e)))?;
+
+        child
+            .stdin
+            .take()
+            .expect("stdin piped")
+            .write_all(&age_bytes)
+            .map_err(|e| ApiError::Internal(format!("write age binary to container: {}", e)))?;
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| ApiError::Internal(format!("docker exec wait (age copy): {}", e)))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ApiError::Internal(format!(
+                "age copy to container failed: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Run the full backup pipeline inside an instance's gateway container:
+    /// tar+gzip to a temp file, age-encrypt, then curl PUT to a presigned S3 URL.
+    /// No archive bytes ever flow through this process — peak memory here is O(1),
+    /// unlike export_instance_data which buffers the whole tar in a Vec.
+    ///
+    /// `stdin_payload` carries the encryption recipients (first line: X25519
+    /// recipient or empty; remaining lines: SSH pubkeys) so they never appear
+    /// in argv. The presigned URL is passed via the BACKUP_URL env var.
+    pub fn backup_instance_in_container(
+        &self,
+        name: &str,
+        service_type: Option<&str>,
+        full_export: bool,
+        backup_id: &str,
+        upload_url: &str,
+        stdin_payload: &str,
+    ) -> Result<(), ApiError> {
+        let container = format!("openclaw-{}-gateway-1", name);
+
+        // --ignore-failed-read: live containers mutate files mid-read and fresh
+        // instances may lack workspace dirs; both downgrade to tar exit 1.
+        let tar_args = if full_export {
+            "--ignore-failed-read -C /home/agent .".to_string()
+        } else {
+            let (config_dir, workspace_dir) = match service_type {
+                Some("ironclaw") => (".ironclaw", "workspace"),
+                Some("openclaw") => (".openclaw", "openclaw"),
+                None => {
+                    return Err(ApiError::Internal(format!(
+                        "Cannot back up instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
+                        name
+                    )));
+                }
+                Some(other) => {
+                    return Err(ApiError::Internal(format!(
+                        "Unknown service_type for backup: '{}' (instance '{}')",
+                        other, name
+                    )));
+                }
+            };
+            format!(
+                "--ignore-failed-read -C /home/agent {} {}",
+                config_dir, workspace_dir
+            )
+        };
+
+        // backup_id comes from a timestamp format — safe to embed in paths.
+        let tarball = format!("/tmp/backup-{}.tar.gz", backup_id);
+        let recipients_file = format!("/tmp/age-r-{}", backup_id);
+        let script = format!(
+            r#"read -r AGE_RCPT
+cat > {rcpt}
+RARG=""
+if [ -n "$AGE_RCPT" ]; then RARG="-r $AGE_RCPT"; fi
+RFLAG=""
+if [ -s {rcpt} ]; then RFLAG="-R {rcpt}"; fi
+if [ -z "$RARG$RFLAG" ]; then echo "no encryption recipients" >&2; exit 3; fi
+trap 'rm -f {tar} {tar}.age {rcpt}' EXIT
+tar czf {tar} {tar_args}
+rc=$?
+if [ $rc -gt 1 ]; then echo "tar failed rc=$rc" >&2; exit $rc; fi
+/tmp/age -e $RARG $RFLAG -o {tar}.age {tar} || exit 4
+curl --fail -sS -T {tar}.age "$BACKUP_URL"
+"#,
+            rcpt = recipients_file,
+            tar = tarball,
+            tar_args = tar_args,
+        );
+
+        let mut child = docker_command()
+            .args([
+                "exec",
+                "-i",
+                "-e",
+                &format!("BACKUP_URL={}", upload_url),
+                &container,
+                "sh",
+                "-c",
+                &script,
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ApiError::Internal(format!("docker exec spawn (backup): {}", e)))?;
+
+        child
+            .stdin
+            .take()
+            .expect("stdin piped")
+            .write_all(stdin_payload.as_bytes())
+            .map_err(|e| ApiError::Internal(format!("write recipients to container: {}", e)))?;
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| ApiError::Internal(format!("docker exec wait (backup): {}", e)))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ApiError::Internal(format!(
+                "in-container backup failed (exit {:?}): {}",
+                output.status.code(),
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+
     /// Import workspace and config data into an instance's gateway container.
     /// Extracts the given tar archive (same format as export_instance_data) into /home/agent.
     pub fn import_instance_data(&self, name: &str, tar_bytes: &[u8]) -> Result<(), ApiError> {

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -796,22 +796,7 @@ impl ComposeManager {
             // Export everything in /home/agent
             args.push(".");
         } else {
-            let (config_dir, workspace_dir) = match service_type {
-                Some("ironclaw") => (".ironclaw", "workspace"),
-                Some("openclaw") => (".openclaw", "openclaw"),
-                None => {
-                    return Err(ApiError::Internal(format!(
-                        "Cannot export instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
-                        name
-                    )));
-                }
-                Some(other) => {
-                    return Err(ApiError::Internal(format!(
-                        "Unknown service_type for export: '{}' (instance '{}')",
-                        other, name
-                    )));
-                }
-            };
+            let (config_dir, workspace_dir) = instance_data_dirs(name, service_type)?;
             args.push(config_dir);
             args.push(workspace_dir);
         }
@@ -857,39 +842,18 @@ impl ComposeManager {
         let age_bytes = std::fs::read(&age_path)
             .map_err(|e| ApiError::Internal(format!("read age binary {}: {}", age_path, e)))?;
 
-        let mut child = docker_command()
-            .args([
+        run_docker_exec_stdin(
+            &[
                 "exec",
                 "-i",
                 &container,
                 "sh",
                 "-c",
                 "cat > /tmp/.age.tmp && chmod 0755 /tmp/.age.tmp && mv /tmp/.age.tmp /tmp/age",
-            ])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| ApiError::Internal(format!("docker exec spawn (age copy): {}", e)))?;
-
-        child
-            .stdin
-            .take()
-            .expect("stdin piped")
-            .write_all(&age_bytes)
-            .map_err(|e| ApiError::Internal(format!("write age binary to container: {}", e)))?;
-
-        let output = child
-            .wait_with_output()
-            .map_err(|e| ApiError::Internal(format!("docker exec wait (age copy): {}", e)))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(ApiError::Internal(format!(
-                "age copy to container failed: {}",
-                stderr.trim()
-            )));
-        }
-        Ok(())
+            ],
+            &age_bytes,
+            "age copy to container",
+        )
     }
 
     /// Run the full backup pipeline inside an instance's gateway container:
@@ -897,9 +861,9 @@ impl ComposeManager {
     /// No archive bytes ever flow through this process — peak memory here is O(1),
     /// unlike export_instance_data which buffers the whole tar in a Vec.
     ///
-    /// `stdin_payload` carries the encryption recipients (first line: X25519
-    /// recipient or empty; remaining lines: SSH pubkeys) so they never appear
-    /// in argv. The presigned URL is passed via the BACKUP_URL env var.
+    /// `stdin_payload` carries the encryption recipients (see build_backup_script
+    /// for the protocol) so they never appear in argv. The presigned URL is
+    /// passed via the BACKUP_URL env var.
     pub fn backup_instance_in_container(
         &self,
         name: &str,
@@ -916,53 +880,16 @@ impl ComposeManager {
         let tar_args = if full_export {
             "--ignore-failed-read -C /home/agent .".to_string()
         } else {
-            let (config_dir, workspace_dir) = match service_type {
-                Some("ironclaw") => (".ironclaw", "workspace"),
-                Some("openclaw") => (".openclaw", "openclaw"),
-                None => {
-                    return Err(ApiError::Internal(format!(
-                        "Cannot back up instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
-                        name
-                    )));
-                }
-                Some(other) => {
-                    return Err(ApiError::Internal(format!(
-                        "Unknown service_type for backup: '{}' (instance '{}')",
-                        other, name
-                    )));
-                }
-            };
+            let (config_dir, workspace_dir) = instance_data_dirs(name, service_type)?;
             format!(
                 "--ignore-failed-read -C /home/agent {} {}",
                 config_dir, workspace_dir
             )
         };
 
-        // backup_id comes from a timestamp format — safe to embed in paths.
-        let tarball = format!("/tmp/backup-{}.tar.gz", backup_id);
-        let recipients_file = format!("/tmp/age-r-{}", backup_id);
-        let script = format!(
-            r#"read -r AGE_RCPT
-cat > {rcpt}
-RARG=""
-if [ -n "$AGE_RCPT" ]; then RARG="-r $AGE_RCPT"; fi
-RFLAG=""
-if [ -s {rcpt} ]; then RFLAG="-R {rcpt}"; fi
-if [ -z "$RARG$RFLAG" ]; then echo "no encryption recipients" >&2; exit 3; fi
-trap 'rm -f {tar} {tar}.age {rcpt}' EXIT
-tar czf {tar} {tar_args}
-rc=$?
-if [ $rc -gt 1 ]; then echo "tar failed rc=$rc" >&2; exit $rc; fi
-/tmp/age -e $RARG $RFLAG -o {tar}.age {tar} || exit 4
-curl --fail -sS -T {tar}.age "$BACKUP_URL"
-"#,
-            rcpt = recipients_file,
-            tar = tarball,
-            tar_args = tar_args,
-        );
-
-        let mut child = docker_command()
-            .args([
+        let script = build_backup_script(backup_id, &tar_args);
+        run_docker_exec_stdin(
+            &[
                 "exec",
                 "-i",
                 "-e",
@@ -971,32 +898,10 @@ curl --fail -sS -T {tar}.age "$BACKUP_URL"
                 "sh",
                 "-c",
                 &script,
-            ])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .spawn()
-            .map_err(|e| ApiError::Internal(format!("docker exec spawn (backup): {}", e)))?;
-
-        child
-            .stdin
-            .take()
-            .expect("stdin piped")
-            .write_all(stdin_payload.as_bytes())
-            .map_err(|e| ApiError::Internal(format!("write recipients to container: {}", e)))?;
-
-        let output = child
-            .wait_with_output()
-            .map_err(|e| ApiError::Internal(format!("docker exec wait (backup): {}", e)))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(ApiError::Internal(format!(
-                "in-container backup failed (exit {:?}): {}",
-                output.status.code(),
-                stderr.trim()
-            )));
-        }
-        Ok(())
+            ],
+            stdin_payload.as_bytes(),
+            "in-container backup",
+        )
     }
 
     /// Import workspace and config data into an instance's gateway container.
@@ -1527,6 +1432,93 @@ curl --fail -sS -T {tar}.age "$BACKUP_URL"
     }
 }
 
+/// Resolve the (config_dir, workspace_dir) pair under /home/agent that holds
+/// an instance's data, by service type.
+fn instance_data_dirs(
+    name: &str,
+    service_type: Option<&str>,
+) -> Result<(&'static str, &'static str), ApiError> {
+    match service_type {
+        Some("ironclaw") => Ok((".ironclaw", "workspace")),
+        Some("openclaw") => Ok((".openclaw", "openclaw")),
+        None => Err(ApiError::Internal(format!(
+            "Cannot export instance '{}': service_type is unknown (set SERVICE_TYPE in .env or recreate with correct type)",
+            name
+        ))),
+        Some(other) => Err(ApiError::Internal(format!(
+            "Unknown service_type for export: '{}' (instance '{}')",
+            other, name
+        ))),
+    }
+}
+
+/// Build the shell script that runs the backup pipeline inside a worker
+/// container: tar+gzip to a temp file, age-encrypt, curl PUT to $BACKUP_URL.
+///
+/// stdin protocol: first line is an X25519 recipient ("age1...") or empty;
+/// remaining lines are SSH pubkeys, written to a file for age -R. At least
+/// one recipient is required (exit 3 otherwise). tar exit 1 ("file changed
+/// as we read it" on live containers) is tolerated; >1 is fatal. Temp file
+/// names embed the backup id so concurrent backups of the same instance
+/// don't collide, and a trap removes them on every exit path.
+fn build_backup_script(backup_id: &str, tar_args: &str) -> String {
+    let tarball = format!("/tmp/backup-{}.tar.gz", backup_id);
+    let recipients_file = format!("/tmp/age-r-{}", backup_id);
+    format!(
+        r#"read -r AGE_RCPT
+cat > {rcpt}
+RARG=""
+if [ -n "$AGE_RCPT" ]; then RARG="-r $AGE_RCPT"; fi
+RFLAG=""
+if [ -s {rcpt} ]; then RFLAG="-R {rcpt}"; fi
+if [ -z "$RARG$RFLAG" ]; then echo "no encryption recipients" >&2; exit 3; fi
+trap 'rm -f {tar} {tar}.age {rcpt}' EXIT
+tar czf {tar} {tar_args}
+rc=$?
+if [ $rc -gt 1 ]; then echo "tar failed rc=$rc" >&2; exit $rc; fi
+/tmp/age -e $RARG $RFLAG -o {tar}.age {tar} || exit 4
+curl --fail -sS -T {tar}.age "$BACKUP_URL"
+"#,
+        rcpt = recipients_file,
+        tar = tarball,
+        tar_args = tar_args,
+    )
+}
+
+/// Spawn a docker command with piped stdin, write `stdin_bytes`, and wait.
+/// Closing stdin (by dropping it after the write) signals EOF to the
+/// container-side script. `context` labels error messages.
+fn run_docker_exec_stdin(args: &[&str], stdin_bytes: &[u8], context: &str) -> Result<(), ApiError> {
+    let mut child = docker_command()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| ApiError::Internal(format!("docker exec spawn ({}): {}", context, e)))?;
+
+    child
+        .stdin
+        .take()
+        .expect("stdin piped")
+        .write_all(stdin_bytes)
+        .map_err(|e| ApiError::Internal(format!("write stdin ({}): {}", context, e)))?;
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| ApiError::Internal(format!("docker exec wait ({}): {}", context, e)))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ApiError::Internal(format!(
+            "{} failed (exit {:?}): {}",
+            context,
+            output.status.code(),
+            stderr.trim()
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(not(test))]
 fn docker_command() -> Command {
     Command::new("docker")
@@ -1538,5 +1530,41 @@ fn docker_command() -> Command {
         Command::new(path)
     } else {
         Command::new("docker")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_backup_script_paths_embed_backup_id() {
+        let script = build_backup_script("20260611T120000Z", "-C /home/agent .");
+        assert!(script.contains("/tmp/backup-20260611T120000Z.tar.gz"));
+        assert!(script.contains("/tmp/age-r-20260611T120000Z"));
+        assert!(script.contains("tar czf /tmp/backup-20260611T120000Z.tar.gz -C /home/agent ."));
+    }
+
+    #[test]
+    fn test_build_backup_script_cleans_up_and_uploads() {
+        let script = build_backup_script("id1", "-C /home/agent .");
+        assert!(script.contains(
+            "trap 'rm -f /tmp/backup-id1.tar.gz /tmp/backup-id1.tar.gz.age /tmp/age-r-id1' EXIT"
+        ));
+        assert!(script.contains(r#"curl --fail -sS -T /tmp/backup-id1.tar.gz.age "$BACKUP_URL""#));
+    }
+
+    #[test]
+    fn test_instance_data_dirs() {
+        assert_eq!(
+            instance_data_dirs("x", Some("ironclaw")).unwrap(),
+            (".ironclaw", "workspace")
+        );
+        assert_eq!(
+            instance_data_dirs("x", Some("openclaw")).unwrap(),
+            (".openclaw", "openclaw")
+        );
+        assert!(instance_data_dirs("x", None).is_err());
+        assert!(instance_data_dirs("x", Some("weird")).is_err());
     }
 }

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -831,12 +831,27 @@ impl ComposeManager {
         Ok(output.stdout)
     }
 
-    /// Copy the age binary into an instance's gateway container (to /tmp/age).
-    /// Streamed via docker exec stdin because docker cp does not work reliably
-    /// across storage drivers. Written atomically (tmp + mv) so concurrent
-    /// backups of the same instance cannot observe a partially-written binary.
+    /// Ensure the age binary is present at /tmp/age in an instance's gateway
+    /// container. No-op if it's already there (the container persists across
+    /// backups), otherwise streams it in via docker exec stdin — docker cp
+    /// does not work reliably across storage drivers. Written to a PID-unique
+    /// temp path then atomically renamed, so concurrent copies can't observe a
+    /// partially-written binary.
     pub fn copy_age_to_container(&self, name: &str) -> Result<(), ApiError> {
         let container = format!("openclaw-{}-gateway-1", name);
+
+        // Skip the ~8MB stream if a usable binary is already in place.
+        let present = docker_command()
+            .args(["exec", &container, "test", "-x", "/tmp/age"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if present {
+            return Ok(());
+        }
+
         let age_path =
             std::env::var("AGE_BINARY_PATH").unwrap_or_else(|_| "/usr/local/bin/age".to_string());
         let age_bytes = std::fs::read(&age_path)
@@ -849,7 +864,7 @@ impl ComposeManager {
                 &container,
                 "sh",
                 "-c",
-                "cat > /tmp/.age.tmp && chmod 0755 /tmp/.age.tmp && mv /tmp/.age.tmp /tmp/age",
+                "t=/tmp/.age.$$.tmp; cat > \"$t\" && chmod 0755 \"$t\" && mv \"$t\" /tmp/age",
             ],
             &age_bytes,
             "age copy to container",
@@ -1452,42 +1467,53 @@ fn instance_data_dirs(
     }
 }
 
+/// Total wall-clock cap for the in-container S3 upload. Keeps curl from
+/// hanging forever on a stalled connection — without it the docker exec (and
+/// the host blocking thread waiting on it) could be pinned indefinitely, since
+/// the outer tokio timeout stops awaiting but cannot kill the child.
+const UPLOAD_CURL_MAX_SECS: u32 = 600;
+const UPLOAD_CURL_CONNECT_SECS: u32 = 30;
+
 /// Build the shell script that runs the backup pipeline inside a worker
 /// container: tar+gzip to a temp file, age-encrypt, curl PUT to $BACKUP_URL.
 ///
 /// stdin protocol: first line is an X25519 recipient ("age1...") or empty;
 /// remaining lines are SSH pubkeys, written to a file for age -R. At least
 /// one recipient is required (exit 3 otherwise). tar exit 1 ("file changed
-/// as we read it" on live containers) is tolerated; >1 is fatal. Temp file
-/// names embed the backup id so concurrent backups of the same instance
-/// don't collide, and a trap removes them on every exit path.
+/// as we read it" on live containers) is tolerated; >1 is fatal. Temp paths
+/// embed the backup id (readability) plus the shell PID `$$` so concurrent
+/// backups of the same instance can't collide, and a trap removes them on
+/// every exit path.
 fn build_backup_script(backup_id: &str, tar_args: &str) -> String {
-    let tarball = format!("/tmp/backup-{}.tar.gz", backup_id);
-    let recipients_file = format!("/tmp/age-r-{}", backup_id);
     format!(
         r#"read -r AGE_RCPT
-cat > {rcpt}
+TAR=/tmp/backup-{id}-$$.tar.gz
+RCPT=/tmp/age-r-{id}-$$
+cat > "$RCPT"
 RARG=""
 if [ -n "$AGE_RCPT" ]; then RARG="-r $AGE_RCPT"; fi
 RFLAG=""
-if [ -s {rcpt} ]; then RFLAG="-R {rcpt}"; fi
+if [ -s "$RCPT" ]; then RFLAG="-R $RCPT"; fi
 if [ -z "$RARG$RFLAG" ]; then echo "no encryption recipients" >&2; exit 3; fi
-trap 'rm -f {tar} {tar}.age {rcpt}' EXIT
-tar czf {tar} {tar_args}
+trap 'rm -f "$TAR" "$TAR.age" "$RCPT"' EXIT
+tar czf "$TAR" {tar_args}
 rc=$?
 if [ $rc -gt 1 ]; then echo "tar failed rc=$rc" >&2; exit $rc; fi
-/tmp/age -e $RARG $RFLAG -o {tar}.age {tar} || exit 4
-curl --fail -sS -T {tar}.age "$BACKUP_URL"
+/tmp/age -e $RARG $RFLAG -o "$TAR.age" "$TAR" || exit 4
+curl --fail --connect-timeout {connect} --max-time {maxt} -sS -T "$TAR.age" "$BACKUP_URL"
 "#,
-        rcpt = recipients_file,
-        tar = tarball,
+        id = backup_id,
         tar_args = tar_args,
+        connect = UPLOAD_CURL_CONNECT_SECS,
+        maxt = UPLOAD_CURL_MAX_SECS,
     )
 }
 
 /// Spawn a docker command with piped stdin, write `stdin_bytes`, and wait.
-/// Closing stdin (by dropping it after the write) signals EOF to the
-/// container-side script. `context` labels error messages.
+/// The write runs on a separate thread so a large payload (e.g. the ~8MB age
+/// binary) can't deadlock against the child filling its stderr pipe while we
+/// block on stdin. Dropping stdin when the writer thread ends signals EOF.
+/// `context` labels error messages.
 fn run_docker_exec_stdin(args: &[&str], stdin_bytes: &[u8], context: &str) -> Result<(), ApiError> {
     let mut child = docker_command()
         .args(args)
@@ -1497,16 +1523,21 @@ fn run_docker_exec_stdin(args: &[&str], stdin_bytes: &[u8], context: &str) -> Re
         .spawn()
         .map_err(|e| ApiError::Internal(format!("docker exec spawn ({}): {}", context, e)))?;
 
-    child
-        .stdin
-        .take()
-        .expect("stdin piped")
-        .write_all(stdin_bytes)
-        .map_err(|e| ApiError::Internal(format!("write stdin ({}): {}", context, e)))?;
+    let mut stdin = child.stdin.take().expect("stdin piped");
+    let payload = stdin_bytes.to_vec();
+    let writer = std::thread::spawn(move || stdin.write_all(&payload));
 
     let output = child
         .wait_with_output()
         .map_err(|e| ApiError::Internal(format!("docker exec wait ({}): {}", context, e)))?;
+
+    // Surface a stdin write error only if the child didn't already fail with a
+    // more specific message (a child that exits early closes the pipe, which
+    // shows up here as a broken-pipe write error we'd rather not report).
+    let write_result = writer
+        .join()
+        .map_err(|_| ApiError::Internal(format!("stdin writer panicked ({})", context)))?;
+
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(ApiError::Internal(format!(
@@ -1516,6 +1547,7 @@ fn run_docker_exec_stdin(args: &[&str], stdin_bytes: &[u8], context: &str) -> Re
             stderr.trim()
         )));
     }
+    write_result.map_err(|e| ApiError::Internal(format!("write stdin ({}): {}", context, e)))?;
     Ok(())
 }
 
@@ -1538,20 +1570,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_backup_script_paths_embed_backup_id() {
+    fn test_build_backup_script_paths_embed_backup_id_and_pid() {
         let script = build_backup_script("20260611T120000Z", "-C /home/agent .");
-        assert!(script.contains("/tmp/backup-20260611T120000Z.tar.gz"));
-        assert!(script.contains("/tmp/age-r-20260611T120000Z"));
-        assert!(script.contains("tar czf /tmp/backup-20260611T120000Z.tar.gz -C /home/agent ."));
+        assert!(script.contains("TAR=/tmp/backup-20260611T120000Z-$$.tar.gz"));
+        assert!(script.contains("RCPT=/tmp/age-r-20260611T120000Z-$$"));
+        assert!(script.contains(r#"tar czf "$TAR" -C /home/agent ."#));
     }
 
     #[test]
-    fn test_build_backup_script_cleans_up_and_uploads() {
+    fn test_build_backup_script_cleans_up_and_uploads_with_timeout() {
         let script = build_backup_script("id1", "-C /home/agent .");
-        assert!(script.contains(
-            "trap 'rm -f /tmp/backup-id1.tar.gz /tmp/backup-id1.tar.gz.age /tmp/age-r-id1' EXIT"
-        ));
-        assert!(script.contains(r#"curl --fail -sS -T /tmp/backup-id1.tar.gz.age "$BACKUP_URL""#));
+        assert!(script.contains(r#"trap 'rm -f "$TAR" "$TAR.age" "$RCPT"' EXIT"#));
+        assert!(script.contains("--connect-timeout 30"));
+        assert!(script.contains("--max-time 600"));
+        assert!(script.contains(r#"-T "$TAR.age" "$BACKUP_URL""#));
     }
 
     #[test]

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -328,68 +328,16 @@ impl AppState {
             .flatten()
     }
 
-    async fn compose_export_instance_data(
+    /// Run a blocking ComposeManager call on the blocking thread pool.
+    /// The closure must own its arguments (clone before calling).
+    async fn compose_blocking<T: Send + 'static>(
         &self,
-        name: &str,
-        service_type: Option<&str>,
-        full_export: bool,
-    ) -> Result<Vec<u8>, ApiError> {
+        f: impl FnOnce(&ComposeManager) -> Result<T, ApiError> + Send + 'static,
+    ) -> Result<T, ApiError> {
         let compose = self.compose.clone();
-        let name = name.to_string();
-        let service_type = service_type.map(|s| s.to_string());
-        tokio::task::spawn_blocking(move || {
-            compose.export_instance_data(&name, service_type.as_deref(), full_export)
-        })
-        .await
-        .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
-    }
-
-    async fn compose_import_instance_data(
-        &self,
-        name: &str,
-        tar_bytes: Vec<u8>,
-    ) -> Result<(), ApiError> {
-        let compose = self.compose.clone();
-        let name = name.to_string();
-        tokio::task::spawn_blocking(move || compose.import_instance_data(&name, &tar_bytes))
+        tokio::task::spawn_blocking(move || f(&compose))
             .await
             .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
-    }
-
-    async fn compose_copy_age_to_container(&self, name: &str) -> Result<(), ApiError> {
-        let compose = self.compose.clone();
-        let name = name.to_string();
-        tokio::task::spawn_blocking(move || compose.copy_age_to_container(&name))
-            .await
-            .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
-    }
-
-    async fn compose_backup_in_container(
-        &self,
-        name: &str,
-        service_type: Option<&str>,
-        full_export: bool,
-        backup_id: &str,
-        upload_url: &str,
-        stdin_payload: String,
-    ) -> Result<(), ApiError> {
-        let compose = self.compose.clone();
-        let name = name.to_string();
-        let service_type = service_type.map(|s| s.to_string());
-        let backup_id = backup_id.to_string();
-        let upload_url = upload_url.to_string();
-        tokio::task::spawn_blocking(move || {
-            compose.backup_instance_in_container(
-                &name,
-                service_type.as_deref(),
-                full_export,
-                &backup_id,
-                &upload_url,
-                &stdin_payload,
-            )
-        })
-        .await
-        .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
     }
 }
 
@@ -2803,7 +2751,11 @@ async fn restart_instance(
                     .await;
 
                 let tar_bytes = match state
-                    .compose_export_instance_data(&name, Some(stype), false)
+                    .compose_blocking({
+                        let name = name.clone();
+                        let stype = stype.to_string();
+                        move |c| c.export_instance_data(&name, Some(&stype), false)
+                    })
                     .await
                 {
                     Ok(bytes) => {
@@ -2918,7 +2870,12 @@ async fn restart_instance(
                     }
                     // Rollback succeeded — restore workspace into the old container
                     if !tar_bytes.is_empty() {
-                        let _ = state.compose_import_instance_data(&name, tar_bytes).await;
+                        let _ = state
+                            .compose_blocking({
+                                let name = name.clone();
+                                move |c| c.import_instance_data(&name, &tar_bytes)
+                            })
+                            .await;
                     }
                     let _ = tx
                         .send(sse_error(&format!(
@@ -2953,7 +2910,13 @@ async fn restart_instance(
                         .send(sse_stage("restoring", "Restoring workspace and config..."))
                         .await;
 
-                    if let Err(e) = state.compose_import_instance_data(&name, tar_bytes).await {
+                    let restore = state
+                        .compose_blocking({
+                            let name = name.clone();
+                            move |c| c.import_instance_data(&name, &tar_bytes)
+                        })
+                        .await;
+                    if let Err(e) = restore {
                         let _ = tx.send(sse_error(&format!(
                             "Failed to restore workspace, the instance may be missing user data: {}", e
                         ))).await;
@@ -3357,20 +3320,26 @@ async fn run_container_backup(
         full_export
     );
 
-    state.compose_copy_age_to_container(name).await?;
-
     let upload_url = backup_mgr.upload_url(name, &backup_id).await?;
 
     // On timeout the docker exec keeps running detached; its trap cleans up
     // the container-side temp files when it eventually exits.
-    let pipeline = state.compose_backup_in_container(
-        name,
-        service_type,
-        full_export,
-        &backup_id,
-        &upload_url,
-        stdin_payload,
-    );
+    let pipeline = state.compose_blocking({
+        let name = name.to_string();
+        let service_type = service_type.map(str::to_string);
+        let backup_id = backup_id.clone();
+        move |c| {
+            c.copy_age_to_container(&name)?;
+            c.backup_instance_in_container(
+                &name,
+                service_type.as_deref(),
+                full_export,
+                &backup_id,
+                &upload_url,
+                &stdin_payload,
+            )
+        }
+    });
     tokio::time::timeout(BACKUP_PIPELINE_TIMEOUT, pipeline)
         .await
         .map_err(|_| {

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -45,7 +45,7 @@ mod names;
 mod nginx_conf;
 mod store;
 
-use backup::BackupManager;
+use backup::{build_backup_stdin, BackupInfo, BackupManager};
 use compose::{ComposeManager, DEFAULT_NEARAI_API_URL};
 use error::ApiError;
 use store::{Instance, InstanceStore, PortRange};
@@ -354,6 +354,42 @@ impl AppState {
         tokio::task::spawn_blocking(move || compose.import_instance_data(&name, &tar_bytes))
             .await
             .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
+    }
+
+    async fn compose_copy_age_to_container(&self, name: &str) -> Result<(), ApiError> {
+        let compose = self.compose.clone();
+        let name = name.to_string();
+        tokio::task::spawn_blocking(move || compose.copy_age_to_container(&name))
+            .await
+            .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
+    }
+
+    async fn compose_backup_in_container(
+        &self,
+        name: &str,
+        service_type: Option<&str>,
+        full_export: bool,
+        backup_id: &str,
+        upload_url: &str,
+        stdin_payload: String,
+    ) -> Result<(), ApiError> {
+        let compose = self.compose.clone();
+        let name = name.to_string();
+        let service_type = service_type.map(|s| s.to_string());
+        let backup_id = backup_id.to_string();
+        let upload_url = upload_url.to_string();
+        tokio::task::spawn_blocking(move || {
+            compose.backup_instance_in_container(
+                &name,
+                service_type.as_deref(),
+                full_export,
+                &backup_id,
+                &upload_url,
+                &stdin_payload,
+            )
+        })
+        .await
+        .map_err(|e| ApiError::Internal(format!("task join: {e}")))?
     }
 }
 
@@ -3246,19 +3282,18 @@ async fn create_backup_endpoint(
     let inst = inst.ok_or_else(|| ApiError::NotFound(format!("Instance '{}' not found", name)))?;
 
     let stream = async_stream::stream! {
-        yield Ok(sse_stage("encrypting", "Exporting and encrypting workspace..."));
+        yield Ok(sse_stage("encrypting", "Exporting, encrypting, and uploading from container..."));
 
-        let tar_bytes = match state.compose_export_instance_data(&name, inst.service_type.as_deref(), full_export).await {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                yield Ok(sse_error(&format!("Backup failed: {}", e)));
-                return;
-            }
-        };
-
-        let result = backup_mgr
-            .create_backup(&name, &inst.ssh_pubkey, tar_bytes, age_recipient.as_deref())
-            .await;
+        let result = run_container_backup(
+            &state,
+            &backup_mgr,
+            &name,
+            inst.service_type.as_deref(),
+            &inst.ssh_pubkey,
+            age_recipient.as_deref(),
+            full_export,
+        )
+        .await;
 
         match result {
             Ok(info) => {
@@ -3290,6 +3325,82 @@ async fn create_backup_endpoint(
     };
 
     Ok(unbuffered_sse(stream))
+}
+
+/// Hard ceiling on the in-container backup pipeline (tar + encrypt + upload).
+/// Worst observed case: ~3 min for a 1.7 GB home dir, plus S3 upload time.
+const BACKUP_PIPELINE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// Run a backup entirely inside the instance's gateway container and verify
+/// the result landed in S3. Replaces the old export-to-memory path, which
+/// buffered the whole archive in this process and got OOM-killed on large
+/// home directories (multi-GB npm caches).
+async fn run_container_backup(
+    state: &AppState,
+    backup_mgr: &BackupManager,
+    name: &str,
+    service_type: Option<&str>,
+    ssh_pubkey: &str,
+    age_recipient: Option<&str>,
+    full_export: bool,
+) -> Result<BackupInfo, ApiError> {
+    // Validate recipients before any side effects.
+    let stdin_payload = build_backup_stdin(age_recipient, ssh_pubkey)?;
+
+    let now = chrono::Utc::now();
+    let backup_id = now.format("%Y%m%dT%H%M%SZ").to_string();
+
+    tracing::info!(
+        "Backup starting: instance={}, id={}, full_export={}",
+        name,
+        backup_id,
+        full_export
+    );
+
+    state.compose_copy_age_to_container(name).await?;
+
+    let upload_url = backup_mgr.upload_url(name, &backup_id).await?;
+
+    // On timeout the docker exec keeps running detached; its trap cleans up
+    // the container-side temp files when it eventually exits.
+    let pipeline = state.compose_backup_in_container(
+        name,
+        service_type,
+        full_export,
+        &backup_id,
+        &upload_url,
+        stdin_payload,
+    );
+    tokio::time::timeout(BACKUP_PIPELINE_TIMEOUT, pipeline)
+        .await
+        .map_err(|_| {
+            ApiError::Internal(format!(
+                "backup pipeline timed out after {}s (instance '{}')",
+                BACKUP_PIPELINE_TIMEOUT.as_secs(),
+                name
+            ))
+        })??;
+
+    let size_bytes = backup_mgr.object_size(name, &backup_id).await?;
+    if size_bytes == 0 {
+        return Err(ApiError::Internal(format!(
+            "backup upload verification failed: S3 object is empty (instance '{}', id {})",
+            name, backup_id
+        )));
+    }
+
+    tracing::info!(
+        "Backup complete: instance={}, id={}, size_bytes={}",
+        name,
+        backup_id,
+        size_bytes
+    );
+
+    Ok(BackupInfo {
+        id: backup_id,
+        timestamp: now,
+        size_bytes,
+    })
 }
 
 #[utoipa::path(get, path = "/instances/{name}/backups", tag = "Backups",
@@ -4689,27 +4800,16 @@ async fn background_sync_loop(state: AppState) {
                         continue;
                     }
                     tracing::info!("Scheduled backup for instance: {}", inst.name);
-                    let tar_bytes = match state
-                        .compose_export_instance_data(
-                            &inst.name,
-                            inst.service_type.as_deref(),
-                            false,
-                        )
-                        .await
-                    {
-                        Ok(bytes) => bytes,
-                        Err(e) => {
-                            tracing::warn!(
-                                "Scheduled backup export failed for {}: {}",
-                                inst.name,
-                                e
-                            );
-                            continue;
-                        }
-                    };
-                    match backup_mgr
-                        .create_backup(&inst.name, &inst.ssh_pubkey, tar_bytes, None)
-                        .await
+                    match run_container_backup(
+                        &state,
+                        backup_mgr,
+                        &inst.name,
+                        inst.service_type.as_deref(),
+                        &inst.ssh_pubkey,
+                        None,
+                        false,
+                    )
+                    .await
                     {
                         Ok(info) => {
                             tracing::info!(


### PR DESCRIPTION
## Context

We found that migration backups OOM-kill compose-api — the kernel killed it at ~4GB RSS three times (confirmed in `dmesg`), because `full_export=true` backups buffer the entire 1.7GB home dir (mostly npm caches) into a `Vec<u8>` before gzip+encrypt+upload:

```
Out of memory: Killed process 2845910 (openclaw-compos) total-vm:7259584kB, anon-rss:4226672kB
```

This PR moves the whole backup pipeline inside the worker container (CrabShack-style): compose-api just presigns an S3 PUT URL, copies the `age` binary in, runs one `docker exec` script (tar → age → curl), and HEAD-verifies the result. Its memory stays O(1) regardless of archive size. We proved the pipeline manually on the real 1.7GB container before writing any Rust (3 min, no OOM).

## Changes, in suggested reading order

1. **The orchestrator** — [`run_container_backup`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/main.rs#L3301): validate recipients → presign → copy age + run pipeline (one blocking task, under a 600s timeout) → HEAD-verify size. This replaces export-to-memory + `create_backup` on the classic backup path.
2. **The script** — [`build_backup_script`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/compose.rs#L1464): pure function, the stdin recipient protocol and tar-exit-1 tolerance documented above it. This is where encryption moved from the `age` crate to the `age` CLI.
3. **The exec plumbing** — [`backup_instance_in_container`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/compose.rs#L867), [`copy_age_to_container`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/compose.rs#L838), shared [`run_docker_exec_stdin`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/compose.rs#L1491).
4. **S3 + recipients** — [`upload_url`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/backup.rs#L62), [`object_size`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/backup.rs#L88), [`build_backup_stdin`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/backup.rs#L179) (validation happens here, before any side effects).
5. **The two callers** — SSE endpoint [`create_backup_endpoint`](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/main.rs#L3217) (event shapes unchanged, so chat-api needs no changes) and the [scheduled loop](https://github.com/nearai/openclaw-nearai-worker/blob/backup-in-container/compose-api/src/main.rs#L4771).

Deleted: the old `create_backup` (in-process gzip + age-crate encryption), the four hand-rolled `spawn_blocking` wrappers (now one generic `compose_blocking`), and the `flate2` dependency. S3 key format and archive format are unchanged, so `list_backups` / `download_url` / restore tooling are unaffected.

## Validation

E2E on a throwaway GCE node, compose-api hard-capped at **2GB RAM** (the dev CVM that OOM'd had 7.3GB; the cap makes the assertion strict — buffering the archive would cgroup-kill it):

- **Single `full_export` backup of a 4.9GB home → 3.8GB encrypted archive uploaded to S3.** compose-api held at **80MB RSS** throughout, `RestartCount=0`, `OOMKilled=false`. Downloaded, age-decrypted, and confirmed the archive contains the full `/home/agent` tree (56,787 entries).
- **Two concurrent `full_export` backups** (the migration-concurrency scenario that previously crashed compose-api): both completed, compose-api peaked at **67MB RSS**, `RestartCount=0`, `OOMKilled=false`.
- `cargo check` clean, 118 unit tests pass (8 new: recipient stdin builder, script builder, dir resolution).
## Known limitation

The instance **upgrade** flow still buffers exports in memory (`export_instance_data` + `import_instance_data`) — its data round-trips through compose-api rather than going to S3, so it needs a different fix (stream to a temp file). `MAX_EXPORT_BYTES` (512MB) bounds what proceeds, but only after the buffer is built. Left for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

