### PR TITLE
Add OpenClaw Grafana telemetry collector

### DIFF
--- a/deploy/.env.dstack.example
+++ b/deploy/.env.dstack.example
@@ -7,6 +7,11 @@ CERTBOT_EMAIL=admin@example.com
 OPENCLAW_IMAGE=openclaw-nearai-worker:local
 IRONCLAW_IMAGE=ironclaw-nearai-worker:local
 
+# Grafana / Prometheus migration telemetry
+OTELCOL_IMAGE=otel/opentelemetry-collector-contrib:0.120.0
+MONITORING_OTLP_ENDPOINT=https://telemetry.infra.near.ai
+MONITORING_INGEST_TOKEN=<token>
+
 # Updater configuration
 COMPOSE_API_IMAGE=openclaw-compose-api:local
 COMPOSE_API_IMAGE_REPO=docker.io/youruser/openclaw-compose-api

--- a/deploy/.env.dstack.example
+++ b/deploy/.env.dstack.example
@@ -8,6 +8,8 @@ OPENCLAW_IMAGE=openclaw-nearai-worker:local
 IRONCLAW_IMAGE=ironclaw-nearai-worker:local
 
 # Grafana / Prometheus migration telemetry
+# Third-party collector image is intentionally pinned and updated by compose
+# changes, not by openclaw-updater's first-party image auto-update loop.
 OTELCOL_IMAGE=otel/opentelemetry-collector-contrib:0.120.0
 MONITORING_OTLP_ENDPOINT=https://telemetry.infra.near.ai
 MONITORING_INGEST_TOKEN=<token>

--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -199,9 +199,6 @@ configs:
           excluded_images:
             - /.*openclaw-nearai-worker.*/
             - /.*ironclaw-nearai-worker.*/
-          container_labels_to_metric_labels:
-            com.docker.compose.service: compose_service
-            com.docker.compose.project: compose_project
 
         prometheus/self:
           config:
@@ -234,9 +231,17 @@ configs:
             - key: service.namespace
               value: near-ai
               action: insert
-            - key: service.name
-              value: openclaw-management-stack
-              action: insert
+
+        transform/datadog_container_labels:
+          error_mode: ignore
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["image_name"], attributes["container.image.name"]) where attributes["image_name"] == nil and attributes["container.image.name"] != nil
+                - delete_key(attributes, "container.id")
+                - delete_key(attributes, "container.hostname")
+                - delete_key(attributes, "container.image.name")
+                - delete_key(attributes, "container.runtime")
 
         filter/drop_worker_containers:
           error_mode: ignore
@@ -268,7 +273,7 @@ configs:
         pipelines:
           metrics:
             receivers: [hostmetrics, docker_stats, prometheus/self]
-            processors: [memory_limiter, resource, filter/drop_worker_containers, batch]
+            processors: [memory_limiter, resource, transform/datadog_container_labels, filter/drop_worker_containers, batch]
             exporters: [otlphttp/gateway]
         telemetry:
           metrics:

--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -147,7 +147,7 @@ services:
     command: ["--config=/etc/otelcol-contrib/config.yaml"]
     user: "0:0"
     environment:
-      - MONITORING_INGEST_TOKEN=${MONITORING_INGEST_TOKEN}
+      - MONITORING_INGEST_TOKEN=${MONITORING_INGEST_TOKEN:-}
       - MONITORING_OTLP_ENDPOINT=${MONITORING_OTLP_ENDPOINT:-https://telemetry.infra.near.ai}
       - DD_HOSTNAME=${DD_HOSTNAME:-openclaw-management-stack}
       - CVM_NAME=${CVM_NAME:-openclaw-management-stack}
@@ -156,8 +156,6 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/hostfs:ro
-      - /proc:/hostfs/proc:ro
-      - /sys:/hostfs/sys:ro
       - otelcol-storage:/var/lib/otelcol-contrib
     configs:
       - source: otelcol_openclaw_config
@@ -244,8 +242,7 @@ configs:
           error_mode: ignore
           metrics:
             datapoint:
-              - 'resource.attributes["container.name"] != nil and IsMatch(resource.attributes["container.name"], "^/?openclaw-.*-gateway-1$")'
-              - 'attributes["compose_project"] != nil and IsMatch(attributes["compose_project"], "^openclaw-")'
+              - 'resource.attributes["container.name"] != nil and IsMatch(resource.attributes["container.name"], "^/?(openclaw|ironclaw)-.*-gateway-[0-9]+$")'
 
         batch:
           send_batch_size: 1024

--- a/deploy/docker-compose.dstack.yml
+++ b/deploy/docker-compose.dstack.yml
@@ -141,10 +141,143 @@ services:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
     restart: unless-stopped
 
+  otelcol-contrib:
+    image: ${OTELCOL_IMAGE:-otel/opentelemetry-collector-contrib:0.120.0}
+    container_name: otelcol-contrib
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    user: "0:0"
+    environment:
+      - MONITORING_INGEST_TOKEN=${MONITORING_INGEST_TOKEN}
+      - MONITORING_OTLP_ENDPOINT=${MONITORING_OTLP_ENDPOINT:-https://telemetry.infra.near.ai}
+      - DD_HOSTNAME=${DD_HOSTNAME:-openclaw-management-stack}
+      - CVM_NAME=${CVM_NAME:-openclaw-management-stack}
+      - CVM_HOST=${CVM_HOST:-}
+      - ENV=${ENV:-dev}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/hostfs:ro
+      - /proc:/hostfs/proc:ro
+      - /sys:/hostfs/sys:ro
+      - otelcol-storage:/var/lib/otelcol-contrib
+    configs:
+      - source: otelcol_openclaw_config
+        target: /etc/otelcol-contrib/config.yaml
+        mode: 0444
+    restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-size: "20m"
+        max-file: "3"
+
 configs:
   docker_registry_config:
     content: |
       {"auths":{"https://index.docker.io/v1/":{"auth":"${DOCKER_REGISTRY_AUTH:-}"}}}
+
+  otelcol_openclaw_config:
+    content: |
+      receivers:
+        hostmetrics:
+          root_path: /hostfs
+          collection_interval: 30s
+          scrapers:
+            cpu: {}
+            memory: {}
+            load: {}
+            paging: {}
+            network: {}
+            disk: {}
+            filesystem:
+              exclude_mount_points:
+                mount_points: ["^/dev(/.*)?$", "^/proc(/.*)?$", "^/sys(/.*)?$", "^/run(/.*)?$", "^/var/lib/docker(/.*)?$"]
+                match_type: regexp
+
+        docker_stats:
+          endpoint: unix:///var/run/docker.sock
+          collection_interval: 30s
+          timeout: 10s
+          api_version: "1.44"
+          excluded_images:
+            - /.*openclaw-nearai-worker.*/
+            - /.*ironclaw-nearai-worker.*/
+          container_labels_to_metric_labels:
+            com.docker.compose.service: compose_service
+            com.docker.compose.project: compose_project
+
+        prometheus/self:
+          config:
+            scrape_configs:
+              - job_name: otelcol-openclaw
+                scrape_interval: 30s
+                static_configs:
+                  - targets: ['localhost:8888']
+
+      processors:
+        memory_limiter:
+          check_interval: 1s
+          limit_mib: 256
+          spike_limit_mib: 64
+
+        resource:
+          attributes:
+            - key: host.name
+              value: $${env:DD_HOSTNAME}
+              action: upsert
+            - key: cvm.name
+              value: $${env:CVM_NAME}
+              action: upsert
+            - key: host.machine
+              value: $${env:CVM_HOST}
+              action: insert
+            - key: deployment.environment
+              value: $${env:ENV}
+              action: upsert
+            - key: service.namespace
+              value: near-ai
+              action: insert
+            - key: service.name
+              value: openclaw-management-stack
+              action: insert
+
+        filter/drop_worker_containers:
+          error_mode: ignore
+          metrics:
+            datapoint:
+              - 'resource.attributes["container.name"] != nil and IsMatch(resource.attributes["container.name"], "^/?openclaw-.*-gateway-1$")'
+              - 'attributes["compose_project"] != nil and IsMatch(attributes["compose_project"], "^openclaw-")'
+
+        batch:
+          send_batch_size: 1024
+          send_batch_max_size: 2048
+          timeout: 5s
+
+      exporters:
+        otlphttp/gateway:
+          endpoint: $${env:MONITORING_OTLP_ENDPOINT}
+          headers:
+            Authorization: "Bearer $${env:MONITORING_INGEST_TOKEN}"
+          sending_queue:
+            queue_size: 128
+            storage: file_storage
+
+      extensions:
+        file_storage:
+          directory: /var/lib/otelcol-contrib/storage
+          create_directory: true
+
+      service:
+        extensions: [file_storage]
+        pipelines:
+          metrics:
+            receivers: [hostmetrics, docker_stats, prometheus/self]
+            processors: [memory_limiter, resource, filter/drop_worker_containers, batch]
+            exporters: [otlphttp/gateway]
+        telemetry:
+          metrics:
+            address: localhost:8888
+          logs:
+            level: info
 
   openclaw_nginx:
     content: |
@@ -263,3 +396,4 @@ volumes:
   management-data:
   bastion-data:
   compose-files:
+  otelcol-storage:

--- a/updater/updater.sh
+++ b/updater/updater.sh
@@ -411,7 +411,7 @@ bootstrap() {
     # mid-bootstrap if our config hash changed. Self-updates are handled
     # separately by update_self() which uses a helper container.
     log "Bootstrap: ensuring all services are running..."
-    compose_up -d --remove-orphans cert-init nginx compose-api ssh-bastion datadog-agent
+    compose_up -d --remove-orphans cert-init nginx compose-api ssh-bastion datadog-agent otelcol-contrib
 
     if [ "$fresh_deploy" = true ]; then
         if wait_for_healthy "$HEALTH_TIMEOUT"; then


### PR DESCRIPTION
## Problem

OpenClaw management-stack CVMs publish `system.*`, `docker.*`, and `container.*`
metrics to Datadog through the in-CVM Datadog agent, but the live OpenClaw
dstack compose does not publish equivalent metrics to the Grafana/Prometheus
stack.

This leaves OpenClaw host/container visibility Datadog-only during the migration.

## Changes

- Add an `otelcol-contrib` sidecar to `deploy/docker-compose.dstack.yml`.
- Collect OpenClaw CVM host metrics with the OTel `hostmetrics` receiver.
- Collect management container runtime metrics with the OTel `docker_stats`
  receiver.
- Export metrics to the central telemetry gateway via OTLP/HTTP.
- Keep Datadog unchanged; the new collector exports only to the Grafana path.
- Exclude per-user OpenClaw/IronClaw worker gateway containers from Docker stats
  to avoid high-cardinality user/container labels, matching the existing Datadog
  exclusion intent.
- Update `openclaw-updater` bootstrap reconciliation so it starts
  `otelcol-contrib` with the rest of the management services.
- Document the new telemetry env variables in `.env.dstack.example`.

## Validation

- Parsed `deploy/docker-compose.dstack.yml` with Ruby YAML.
- Parsed the embedded `otelcol_openclaw_config` with Ruby YAML.
- Confirmed upstream OTel v0.120.0 supports `hostmetrics.root_path` and
  `docker_stats.api_version`.
- Ran `bash -n updater/updater.sh`.
- Ran `git diff --check`.

## Rollout Notes

This should be deployed together with the matching cvm-ansible-playbooks PR,
which passes the pinned collector image and telemetry gateway endpoint into the
OpenClaw management-stack CVM env file.
