### PR TITLE
ci: add code format and test checks

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/code-format.yml"
-      - ".github/workflows/test.yml"
       - "compose-api/**"
       - "oauth-service/**"
   workflow_dispatch:
@@ -37,4 +36,4 @@ jobs:
 
       - name: Check formatting
         working-directory: ${{ matrix.path }}
-        run: cargo fmt --all -- --check
+        run: cargo +stable fmt --all -- --check

--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -1,9 +1,10 @@
-name: Pull Request Checks
+name: Code Format
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/pr-checks.yml"
+      - ".github/workflows/code-format.yml"
+      - ".github/workflows/test.yml"
       - "compose-api/**"
       - "oauth-service/**"
   workflow_dispatch:
@@ -13,12 +14,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  NO_PROXY: 127.0.0.1,localhost
-  no_proxy: 127.0.0.1,localhost
 
 jobs:
-  rust:
-    name: ${{ matrix.package }} style and tests
+  rustfmt:
+    name: ${{ matrix.package }} format
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -34,16 +33,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
+        run: rustup toolchain install stable --profile minimal --component rustfmt
 
       - name: Check formatting
         working-directory: ${{ matrix.path }}
         run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        working-directory: ${{ matrix.path }}
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run tests
-        working-directory: ${{ matrix.path }}
-        run: cargo test --all-features

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,49 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/pr-checks.yml"
+      - "compose-api/**"
+      - "oauth-service/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  NO_PROXY: 127.0.0.1,localhost
+  no_proxy: 127.0.0.1,localhost
+
+jobs:
+  rust:
+    name: ${{ matrix.package }} style and tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: openclaw-compose-api
+            path: compose-api
+          - package: ironclaw-oauth-service
+            path: oauth-service
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal --component rustfmt,clippy
+
+      - name: Check formatting
+        working-directory: ${{ matrix.path }}
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        working-directory: ${{ matrix.path }}
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        working-directory: ${{ matrix.path }}
+        run: cargo test --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 on:
   pull_request:
     paths:
-      - ".github/workflows/code-format.yml"
       - ".github/workflows/test.yml"
       - "compose-api/**"
       - "oauth-service/**"
@@ -14,8 +13,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  NO_PROXY: 127.0.0.1,localhost
-  no_proxy: 127.0.0.1,localhost
 
 jobs:
   rust:
@@ -39,4 +36,4 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ matrix.path }}
-        run: cargo test --all-features
+        run: cargo +stable test --all-features --locked

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/code-format.yml"
+      - ".github/workflows/test.yml"
+      - "compose-api/**"
+      - "oauth-service/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  NO_PROXY: 127.0.0.1,localhost
+  no_proxy: 127.0.0.1,localhost
+
+jobs:
+  rust:
+    name: ${{ matrix.package }} tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: openclaw-compose-api
+            path: compose-api
+          - package: ironclaw-oauth-service
+            path: oauth-service
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Run tests
+        working-directory: ${{ matrix.path }}
+        run: cargo test --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 
 # Rust build artifacts
 compose-api/target/
+oauth-service/target/
 
 # Runtime data
 compose-api/data/

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -3230,7 +3230,7 @@ async fn create_backup_endpoint(
     let age_recipient = req.age_recipient;
     let expiry_secs = req.expiry_secs;
     if let Some(secs) = expiry_secs {
-        if secs < 1 || secs > 604800 {
+        if !(1..=604800).contains(&secs) {
             return Err(ApiError::BadRequest(
                 "expiry_secs must be between 1 and 604800 (S3 presigned URL limit)".into(),
             ));


### PR DESCRIPTION
## Summary

- Add a `Code Format` pull request workflow that runs `cargo +stable fmt --all -- --check` for `compose-api` and `oauth-service`.
- Add a separate `Test` pull request workflow that runs `cargo +stable test --all-features --locked` for the same two Rust packages.
- Keep both workflows as package matrices so each package reports independently in the PR checks UI.
- Scope each workflow path filter to its own YAML file plus the Rust package paths.
- Ignore `oauth-service/target/` build artifacts and fix one existing Rust style warning in `compose-api`.

## Validation

- `cargo +stable fmt --all -- --check` in `compose-api`
- `cargo +stable fmt --all -- --check` in `oauth-service`
- `cargo clippy --all-targets --all-features -- -D warnings` in `compose-api`
- `cargo clippy --all-targets --all-features -- -D warnings` in `oauth-service`
- `env -u http_proxy -u https_proxy cargo +stable test --all-features --locked` in `compose-api` (118 tests)
- `env -u http_proxy -u https_proxy cargo +stable test --all-features --locked` in `oauth-service` (9 tests)

Local note: sandboxed test runs cannot bind loopback sockets, and this shell has HTTP proxy variables set. The successful test validation was run outside the sandbox with the local proxy vars unset.