### PR TITLE
fix(compose-api): resolve service_type from the image, and add PATCH /instances/{name} to repair drifted ones

### DIFF
--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -105,7 +105,11 @@ impl BackupManager {
     /// Whether the archive exists. A missing object is `Ok(false)`; every other S3 failure —
     /// outage, auth, throttling — propagates as an error, so a caller can 404 a genuinely absent
     /// backup without masking an operational incident as "not found".
-    pub async fn object_exists(&self, instance_name: &str, backup_id: &str) -> Result<bool, ApiError> {
+    pub async fn object_exists(
+        &self,
+        instance_name: &str,
+        backup_id: &str,
+    ) -> Result<bool, ApiError> {
         let key = backup_s3_key(instance_name, backup_id);
 
         match self

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -505,7 +505,7 @@ impl ComposeManager {
         let net = Self::network_name(instance_name);
         // `docker network create` is idempotent-ish: returns an error if the
         // network already exists, which we ignore.
-        let output = Command::new("docker")
+        let output = docker_command()
             .args(["network", "create", "--driver", "bridge", &net])
             .output()
             .map_err(|e| ApiError::Internal(format!("docker network create: {}", e)))?;

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -51,6 +51,12 @@ pub fn is_managed_env_key(key: &str) -> bool {
 /// Where ironclaw's entrypoint persists the secrets master key, on the config volume.
 const MASTER_KEY_PATH: &str = "/home/agent/.ironclaw/.master_key";
 
+/// The same file, on the same volume, as an openclaw container sees it. Both templates mount
+/// the one `config` volume — ironclaw at `.ironclaw`, openclaw at `.openclaw` — so an instance
+/// recreated onto the openclaw image still carries ironclaw's key, one path over. openclaw
+/// never writes this file, so reading it can only ever return a key the instance already had.
+const MASTER_KEY_PATH_AS_OPENCLAW: &str = "/home/agent/.openclaw/.master_key";
+
 /// The places an instance's SECRETS_MASTER_KEY can be read from, cheapest first.
 /// `docker cp` reads the config volume whether or not the container runs — verified
 /// against a stopped container and one that was never started — so it covers the
@@ -58,16 +64,16 @@ const MASTER_KEY_PATH: &str = "/home/agent/.ironclaw/.master_key";
 #[derive(Clone, Copy)]
 enum MasterKeySource {
     EnvFile,
-    Copy,
-    Exec,
+    Copy(&'static str),
+    Exec(&'static str),
 }
 
 impl MasterKeySource {
-    fn label(self) -> &'static str {
+    fn label(self) -> String {
         match self {
-            Self::EnvFile => "instance .env",
-            Self::Copy => "docker cp",
-            Self::Exec => "docker exec",
+            Self::EnvFile => "instance .env".to_string(),
+            Self::Copy(path) => format!("docker cp {}", path),
+            Self::Exec(path) => format!("docker exec cat {}", path),
         }
     }
 }
@@ -1369,7 +1375,7 @@ impl ComposeManager {
     /// Read SECRETS_MASTER_KEY from a running container's persisted .master_key file.
     /// Discovery's single cheap attempt; `resolve_master_key` covers the rest.
     fn read_master_key_from_container(&self, name: &str, container_name: &str) -> Option<String> {
-        self.read_master_key(MasterKeySource::Exec, name, container_name)
+        self.read_master_key(MasterKeySource::Exec(MASTER_KEY_PATH), name, container_name)
             .ok()
     }
 
@@ -1378,8 +1384,10 @@ impl ComposeManager {
     /// ironclaw writes the key to `.master_key` on the config volume, so it outlives a
     /// stopped container — but the exec used during discovery does not, which is why a
     /// stopped instance stayed unmigratable until someone started it and restarted
-    /// compose-api. Every source logs why it came up empty: an instance that never had a
-    /// key must not look like one whose key we failed to read.
+    /// compose-api. The volume is read at both mount points, because an instance recreated
+    /// onto the openclaw image holds the same key one path over. Every source logs why it
+    /// came up empty: an instance that never had a key must not look like one whose key we
+    /// failed to read.
     pub fn resolve_master_key(
         &self,
         name: &str,
@@ -1396,8 +1404,10 @@ impl ComposeManager {
         let mut missed: Vec<String> = Vec::new();
         for source in [
             MasterKeySource::EnvFile,
-            MasterKeySource::Copy,
-            MasterKeySource::Exec,
+            MasterKeySource::Copy(MASTER_KEY_PATH),
+            MasterKeySource::Copy(MASTER_KEY_PATH_AS_OPENCLAW),
+            MasterKeySource::Exec(MASTER_KEY_PATH),
+            MasterKeySource::Exec(MASTER_KEY_PATH_AS_OPENCLAW),
         ] {
             match self.read_master_key(source, name, container_name) {
                 Ok(key) => {
@@ -1446,12 +1456,12 @@ impl ComposeManager {
                     .ok_or_else(|| "not in the instance .env".to_string())?;
                 valid_master_key(&raw)
             }
-            MasterKeySource::Copy => {
+            MasterKeySource::Copy(path) => {
                 let dest = std::env::temp_dir().join(format!("{}.master_key", container_name));
                 let output = docker_command()
                     .args([
                         "cp",
-                        &format!("{}:{}", container_name, MASTER_KEY_PATH),
+                        &format!("{}:{}", container_name, path),
                         &dest.to_string_lossy(),
                     ])
                     .output()
@@ -1466,9 +1476,9 @@ impl ComposeManager {
                 let _ = std::fs::remove_file(&dest);
                 result
             }
-            MasterKeySource::Exec => {
+            MasterKeySource::Exec(path) => {
                 let output = docker_command()
-                    .args(["exec", container_name, "cat", MASTER_KEY_PATH])
+                    .args(["exec", container_name, "cat", path])
                     .output()
                     .map_err(|e| format!("docker exec failed to run: {}", e))?;
                 if !output.status.success() {

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -215,11 +215,21 @@ impl ComposeManager {
     /// Infer service type from image name: "ironclaw" if image contains "ironclaw", otherwise
     /// "openclaw". Does not depend on which compose files are currently loaded.
     pub fn infer_service_type_from_image(&self, image: Option<&str>) -> &'static str {
+        self.service_type_named_by_image(image)
+            .unwrap_or("openclaw")
+    }
+
+    /// Service type the image name states outright, or `None` when it names neither product.
+    /// Unlike [`Self::infer_service_type_from_image`] this never guesses, so callers can use it
+    /// as evidence rather than as a default.
+    pub fn service_type_named_by_image(&self, image: Option<&str>) -> Option<&'static str> {
         let img_lower = image.unwrap_or("").to_lowercase();
         if img_lower.contains("ironclaw") {
-            "ironclaw"
+            Some("ironclaw")
+        } else if img_lower.contains("openclaw") {
+            Some("openclaw")
         } else {
-            "openclaw"
+            None
         }
     }
 
@@ -1151,8 +1161,12 @@ impl ComposeManager {
             .cloned()
             .filter(|s| !s.is_empty());
         let image_env = env_map.get("OPENCLAW_IMAGE").cloned();
-        // Resolve service_type: label → container env → persisted .env file → infer from image.
-        // Infer from image name so e.g. ironclaw-nearai-worker → ironclaw.
+        // Resolve service_type: label → container env → image name → persisted .env file →
+        // infer from image. The label and the container env are recorded on this container, so
+        // they describe it. The image outranks the .env file because it says which product is
+        // actually running, while the .env only records what a previous resolution concluded —
+        // and a .env that once defaulted to "openclaw" for an ironclaw container keeps that
+        // answer alive forever, which `ensure_env_file` then turns into an image rewrite.
         let image_from_config = v
             .pointer("/Config/Image")
             .and_then(|i| i.as_str())
@@ -1167,6 +1181,22 @@ impl ComposeManager {
                     .get("SERVICE_TYPE")
                     .cloned()
                     .filter(|s| !s.is_empty())
+            })
+            .or_else(|| {
+                let named = self.service_type_named_by_image(Some(image_from_config))?;
+                if self
+                    .read_service_type_from_env_file(name)
+                    .is_some_and(|stored| stored != named)
+                {
+                    tracing::warn!(
+                        "Instance '{}': .env SERVICE_TYPE disagrees with running image '{}', \
+                         using '{}' from the image",
+                        name,
+                        image_from_config,
+                        named
+                    );
+                }
+                Some(named.to_string())
             })
             .or_else(|| self.read_service_type_from_env_file(name))
             .or_else(|| {
@@ -1491,10 +1521,17 @@ impl ComposeManager {
             vars.insert("BASTION_SSH_PUBKEY".into(), bastion_key.clone());
         }
         // Resolve service_type first — needed to validate the image.
-        // Prefer in-memory service_type, then existing .env value; only then default to openclaw.
+        // Prefer in-memory service_type, then what the image names, then the existing .env value;
+        // only then default to openclaw. The image comes before the .env for the same reason as in
+        // `inspect_container`, and the "openclaw" default is last because whatever wins here is
+        // written back to the .env, where a guess would read as fact on every later resolution.
         let service_type = inst
             .service_type
             .clone()
+            .or_else(|| {
+                self.service_type_named_by_image(inst.image.as_deref())
+                    .map(|s| s.to_string())
+            })
             .or_else(|| self.read_service_type_from_env_file(&inst.name))
             .unwrap_or_else(|| "openclaw".to_string());
         // Use the instance's stored image, but if it doesn't match the
@@ -1749,6 +1786,7 @@ fn docker_command() -> Command {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
 
     #[test]
     fn test_valid_master_key_trims_and_rejects_malformed() {
@@ -1788,6 +1826,107 @@ mod tests {
             Some("nearaidev/openclaw-nearai-worker:latest")
         ));
         assert!(!is_ironclaw(None, None));
+    }
+
+    fn test_manager(dir: &Path) -> ComposeManager {
+        let mut files = HashMap::new();
+        for st in ["openclaw", "ironclaw"] {
+            let path = dir.join(format!("{}.yml", st));
+            std::fs::write(&path, "services: {}\n").unwrap();
+            files.insert(st.to_string(), path);
+        }
+        ComposeManager::new(files, dir.join("envs"), None).unwrap()
+    }
+
+    fn test_instance(name: &str, image: Option<&str>, service_type: Option<&str>) -> Instance {
+        Instance {
+            name: name.to_string(),
+            token: "t".into(),
+            gateway_port: 18789,
+            ssh_port: 2222,
+            created_at: Utc::now(),
+            ssh_pubkey: "ssh-ed25519 AAAA".into(),
+            nearai_api_key: "k".into(),
+            nearai_api_url: None,
+            active: true,
+            image: image.map(String::from),
+            image_digest: None,
+            service_type: service_type.map(String::from),
+            mem_limit: None,
+            cpus: None,
+            storage_size: None,
+            extra_env: None,
+        }
+    }
+
+    const IRONCLAW_IMAGE: &str = "nearaidev/ironclaw-nearai-worker@sha256:46c302d3";
+    const OPENCLAW_IMAGE: &str = "nearaidev/openclaw-nearai-worker:latest";
+
+    #[test]
+    fn test_service_type_named_by_image_reports_unknown_instead_of_guessing() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        assert_eq!(
+            m.service_type_named_by_image(Some(IRONCLAW_IMAGE)),
+            Some("ironclaw")
+        );
+        assert_eq!(
+            m.service_type_named_by_image(Some(OPENCLAW_IMAGE)),
+            Some("openclaw")
+        );
+        assert_eq!(m.service_type_named_by_image(Some("busybox:latest")), None);
+        assert_eq!(m.service_type_named_by_image(None), None);
+        // The guessing variant keeps its old contract for callers that need a value.
+        assert_eq!(
+            m.infer_service_type_from_image(Some("busybox:latest")),
+            "openclaw"
+        );
+        assert_eq!(
+            m.infer_service_type_from_image(Some(IRONCLAW_IMAGE)),
+            "ironclaw"
+        );
+    }
+
+    /// An .env left saying `openclaw` for a container running an ironclaw image used to win,
+    /// and `ensure_env_file` then rewrote the image to the openclaw default — so the next
+    /// recreate started the wrong product on the instance's data. The image decides now.
+    #[test]
+    fn test_ensure_env_file_keeps_ironclaw_image_when_env_file_says_openclaw() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        let inst = test_instance("stale-agent", Some(IRONCLAW_IMAGE), None);
+        std::fs::write(m.env_path("stale-agent"), "SERVICE_TYPE=openclaw\n").unwrap();
+
+        m.ensure_env_file(&inst, OPENCLAW_IMAGE, None, None, None)
+            .unwrap();
+
+        let written = std::fs::read_to_string(m.env_path("stale-agent")).unwrap();
+        assert!(
+            written.contains(&format!("OPENCLAW_IMAGE={}", IRONCLAW_IMAGE)),
+            "image was rewritten away from ironclaw: {}",
+            written
+        );
+        assert!(written.contains("SERVICE_TYPE=ironclaw"), "{}", written);
+    }
+
+    #[test]
+    fn test_ensure_env_file_still_repairs_an_image_that_contradicts_a_known_service_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        // service_type is known from the container itself, so an openclaw image on an
+        // ironclaw instance is still corrected to the ironclaw default.
+        let inst = test_instance("mixed-agent", Some(OPENCLAW_IMAGE), Some("ironclaw"));
+
+        m.ensure_env_file(&inst, IRONCLAW_IMAGE, None, None, None)
+            .unwrap();
+
+        let written = std::fs::read_to_string(m.env_path("mixed-agent")).unwrap();
+        assert!(
+            written.contains(&format!("OPENCLAW_IMAGE={}", IRONCLAW_IMAGE)),
+            "{}",
+            written
+        );
+        assert!(written.contains("SERVICE_TYPE=ironclaw"), "{}", written);
     }
 
     #[test]

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -40,6 +40,14 @@ const SYSTEM_ENV_KEYS: &[&str] = &[
     "PATH", "HOME", "HOSTNAME", "LANG", "LC_ALL", "TERM", "SHLVL", "PWD", "OLDPWD", "USER", "SHELL",
 ];
 
+/// Env keys compose-api owns: the ones it writes itself, plus the master key it resolves
+/// from the container. `ensure_env_file` applies `extra_env` after everything else, so an
+/// extra_env entry for one of these silently replaces the managed value — which is why
+/// callers accepting an extra_env patch must refuse them.
+pub fn is_managed_env_key(key: &str) -> bool {
+    CORE_ENV_KEYS.contains(&key) || SYSTEM_ENV_KEYS.contains(&key) || key == "SECRETS_MASTER_KEY"
+}
+
 /// Where ironclaw's entrypoint persists the secrets master key, on the config volume.
 const MASTER_KEY_PATH: &str = "/home/agent/.ironclaw/.master_key";
 

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -215,21 +215,86 @@ impl ComposeManager {
     /// Infer service type from image name: "ironclaw" if image contains "ironclaw", otherwise
     /// "openclaw". Does not depend on which compose files are currently loaded.
     pub fn infer_service_type_from_image(&self, image: Option<&str>) -> &'static str {
-        self.service_type_named_by_image(image)
-            .unwrap_or("openclaw")
+        if image.unwrap_or("").to_lowercase().contains("ironclaw") {
+            "ironclaw"
+        } else {
+            "openclaw"
+        }
     }
 
-    /// Service type the image name states outright, or `None` when it names neither product.
-    /// Unlike [`Self::infer_service_type_from_image`] this never guesses, so callers can use it
-    /// as evidence rather than as a default.
+    /// Service type the image name states outright, or `None` when it names neither product —
+    /// or, ambiguously, both. Unlike [`Self::infer_service_type_from_image`] this never guesses,
+    /// so callers can use it as evidence rather than as a default.
     pub fn service_type_named_by_image(&self, image: Option<&str>) -> Option<&'static str> {
         let img_lower = image.unwrap_or("").to_lowercase();
-        if img_lower.contains("ironclaw") {
-            Some("ironclaw")
-        } else if img_lower.contains("openclaw") {
-            Some("openclaw")
-        } else {
-            None
+        match (
+            img_lower.contains("ironclaw"),
+            img_lower.contains("openclaw"),
+        ) {
+            (true, false) => Some("ironclaw"),
+            (false, true) => Some("openclaw"),
+            _ => None,
+        }
+    }
+
+    /// Decide an instance's service_type from the signals its container carries.
+    ///
+    /// The image decides whenever it names a product, because it is what the container is
+    /// actually running, and service_type only exists to pick the matching compose template
+    /// and binary. The label, the container env and the .env file are all copies of an
+    /// earlier resolution — a "openclaw" recorded against an ironclaw container is exactly
+    /// what `ensure_env_file` turns into an image rewrite, so none of them may outrank the
+    /// image. A container created from a bare image id names no product; there the recorded
+    /// values are used, in their original order.
+    fn resolve_service_type(
+        &self,
+        name: &str,
+        label: Option<&str>,
+        env_map: &HashMap<String, String>,
+        image_from_config: &str,
+    ) -> Option<String> {
+        let recorded = label
+            .map(|s| s.to_string())
+            .or_else(|| {
+                env_map
+                    .get("SERVICE_TYPE")
+                    .cloned()
+                    .filter(|s| !s.is_empty())
+            })
+            .or_else(|| self.read_service_type_from_env_file(name));
+
+        // `.Config.Image` echoes whatever the container was created from, so it is the direct
+        // evidence; OPENCLAW_IMAGE covers the case where that was a bare image id.
+        let named = self
+            .service_type_named_by_image(Some(image_from_config))
+            .or_else(|| {
+                self.service_type_named_by_image(env_map.get("OPENCLAW_IMAGE").map(String::as_str))
+            });
+
+        match named {
+            Some(named) => {
+                if let Some(stale) = recorded.as_deref().filter(|r| *r != named) {
+                    tracing::warn!(
+                        "Instance '{}': recorded service_type '{}' disagrees with the running \
+                         image '{}'; using '{}' from the image",
+                        name,
+                        stale,
+                        image_from_config,
+                        named
+                    );
+                }
+                Some(named.to_string())
+            }
+            None => recorded.or_else(|| {
+                let inferred = self.infer_service_type_from_image(Some(image_from_config));
+                tracing::info!(
+                    "Instance '{}': no SERVICE_TYPE in label/env/.env, inferring '{}' from image '{}'",
+                    name,
+                    inferred,
+                    image_from_config
+                );
+                Some(inferred.to_string())
+            }),
         }
     }
 
@@ -1161,54 +1226,16 @@ impl ComposeManager {
             .cloned()
             .filter(|s| !s.is_empty());
         let image_env = env_map.get("OPENCLAW_IMAGE").cloned();
-        // Resolve service_type: label → container env → image name → persisted .env file →
-        // infer from image. The label and the container env are recorded on this container, so
-        // they describe it. The image outranks the .env file because it says which product is
-        // actually running, while the .env only records what a previous resolution concluded —
-        // and a .env that once defaulted to "openclaw" for an ironclaw container keeps that
-        // answer alive forever, which `ensure_env_file` then turns into an image rewrite.
         let image_from_config = v
             .pointer("/Config/Image")
             .and_then(|i| i.as_str())
             .unwrap_or("");
-        let service_type = v
+        let label_service_type = v
             .pointer("/Config/Labels/openclaw.service_type")
             .and_then(|s| s.as_str())
-            .map(|s| s.to_string())
-            .filter(|s| !s.is_empty())
-            .or_else(|| {
-                env_map
-                    .get("SERVICE_TYPE")
-                    .cloned()
-                    .filter(|s| !s.is_empty())
-            })
-            .or_else(|| {
-                let named = self.service_type_named_by_image(Some(image_from_config))?;
-                if self
-                    .read_service_type_from_env_file(name)
-                    .is_some_and(|stored| stored != named)
-                {
-                    tracing::warn!(
-                        "Instance '{}': .env SERVICE_TYPE disagrees with running image '{}', \
-                         using '{}' from the image",
-                        name,
-                        image_from_config,
-                        named
-                    );
-                }
-                Some(named.to_string())
-            })
-            .or_else(|| self.read_service_type_from_env_file(name))
-            .or_else(|| {
-                let inferred = self.infer_service_type_from_image(Some(image_from_config));
-                tracing::info!(
-                    "Instance '{}': no SERVICE_TYPE in label/env/.env, inferring '{}' from image '{}'",
-                    name,
-                    inferred,
-                    image_from_config
-                );
-                Some(inferred.to_string())
-            });
+            .filter(|s| !s.is_empty());
+        let service_type =
+            self.resolve_service_type(name, label_service_type, &env_map, image_from_config);
 
         if service_type.is_none() {
             tracing::warn!(
@@ -1861,6 +1888,85 @@ mod tests {
 
     const IRONCLAW_IMAGE: &str = "nearaidev/ironclaw-nearai-worker@sha256:46c302d3";
     const OPENCLAW_IMAGE: &str = "nearaidev/openclaw-nearai-worker:latest";
+
+    fn env_map(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// The whole point of the change: whichever copy carries the stale "openclaw" — the
+    /// label, the container env, or the .env file — the running image overrules it.
+    #[test]
+    fn test_resolve_service_type_prefers_the_image_over_every_recorded_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        std::fs::write(m.env_path("a"), "SERVICE_TYPE=openclaw\n").unwrap();
+
+        // stale label
+        assert_eq!(
+            m.resolve_service_type("a", Some("openclaw"), &env_map(&[]), IRONCLAW_IMAGE),
+            Some("ironclaw".into())
+        );
+        // stale container env
+        assert_eq!(
+            m.resolve_service_type(
+                "a",
+                None,
+                &env_map(&[("SERVICE_TYPE", "openclaw")]),
+                IRONCLAW_IMAGE
+            ),
+            Some("ironclaw".into())
+        );
+        // stale .env file only
+        assert_eq!(
+            m.resolve_service_type("a", None, &env_map(&[]), IRONCLAW_IMAGE),
+            Some("ironclaw".into())
+        );
+    }
+
+    #[test]
+    fn test_resolve_service_type_falls_back_to_records_when_the_image_names_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        let bare_id = "sha256:e0e8b3cbfed68a90084781e2962f9c0deead51c5a3f11a488eef0283a4284bc2";
+
+        // A container created from a bare image id carries no product name, so the label wins.
+        assert_eq!(
+            m.resolve_service_type("b", Some("ironclaw"), &env_map(&[]), bare_id),
+            Some("ironclaw".into())
+        );
+        // …and OPENCLAW_IMAGE recovers the name when .Config.Image cannot.
+        assert_eq!(
+            m.resolve_service_type(
+                "b",
+                Some("openclaw"),
+                &env_map(&[("OPENCLAW_IMAGE", IRONCLAW_IMAGE)]),
+                bare_id
+            ),
+            Some("ironclaw".into())
+        );
+        // Nothing recorded and nothing named: the old guess remains.
+        assert_eq!(
+            m.resolve_service_type("b", None, &env_map(&[]), bare_id),
+            Some("openclaw".into())
+        );
+    }
+
+    #[test]
+    fn test_resolve_service_type_keeps_agreeing_signals_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = test_manager(dir.path());
+        assert_eq!(
+            m.resolve_service_type("c", Some("openclaw"), &env_map(&[]), OPENCLAW_IMAGE),
+            Some("openclaw".into())
+        );
+        assert_eq!(
+            m.resolve_service_type("c", Some("ironclaw"), &env_map(&[]), IRONCLAW_IMAGE),
+            Some("ironclaw".into())
+        );
+    }
 
     #[test]
     fn test_service_type_named_by_image_reports_unknown_instead_of_guessing() {

--- a/compose-api/src/compose.rs
+++ b/compose-api/src/compose.rs
@@ -279,31 +279,31 @@ impl ComposeManager {
                 self.service_type_named_by_image(env_map.get("OPENCLAW_IMAGE").map(String::as_str))
             });
 
-        match named {
-            Some(named) => {
-                if let Some(stale) = recorded.as_deref().filter(|r| *r != named) {
-                    tracing::warn!(
-                        "Instance '{}': recorded service_type '{}' disagrees with the running \
-                         image '{}'; using '{}' from the image",
-                        name,
-                        stale,
-                        image_from_config,
-                        named
-                    );
-                }
-                Some(named.to_string())
-            }
-            None => recorded.or_else(|| {
-                let inferred = self.infer_service_type_from_image(Some(image_from_config));
-                tracing::info!(
-                    "Instance '{}': no SERVICE_TYPE in label/env/.env, inferring '{}' from image '{}'",
+        if let Some(named) = named {
+            if let Some(stale) = recorded.as_deref().filter(|r| *r != named) {
+                tracing::warn!(
+                    "Instance '{}': recorded service_type '{}' disagrees with the running \
+                     image '{}'; using '{}' from the image",
                     name,
-                    inferred,
-                    image_from_config
+                    stale,
+                    image_from_config,
+                    named
                 );
-                Some(inferred.to_string())
-            }),
+            }
+            return Some(named.to_string());
         }
+
+        // The image names no product — a container created from a bare image id.
+        recorded.or_else(|| {
+            let inferred = self.infer_service_type_from_image(Some(image_from_config));
+            tracing::info!(
+                "Instance '{}': no SERVICE_TYPE in label/env/.env, inferring '{}' from image '{}'",
+                name,
+                inferred,
+                image_from_config
+            );
+            Some(inferred.to_string())
+        })
     }
 
     /// Resolve the compose file for a given service type, falling back to openclaw.

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -5,7 +5,7 @@ use axum::{
         sse::{Event, Sse},
         IntoResponse, Redirect,
     },
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
     Json, Router,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -64,6 +64,7 @@ use store::{Instance, InstanceStore, PortRange};
         create_instance,
         get_instance,
         delete_instance,
+        patch_instance,
         restart_instance,
         stop_instance,
         start_instance,
@@ -88,6 +89,8 @@ use store::{Instance, InstanceStore, PortRange};
         VersionResponse,
         AppVersionResponse,
         CreateInstanceRequest,
+        PatchInstanceRequest,
+        PatchInstanceResponse,
         RestartInstanceRequest,
         InstanceInfo,
         InstanceResponse,
@@ -1667,6 +1670,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/instances", post(create_instance))
         .route("/instances/{name}", get(get_instance))
         .route("/instances/{name}", delete(delete_instance))
+        .route("/instances/{name}", patch(patch_instance))
         .route("/instances/{name}/restart", post(restart_instance))
         .route("/instances/{name}/stop", post(stop_instance))
         .route("/instances/{name}/start", post(start_instance))
@@ -2698,6 +2702,208 @@ async fn delete_instance(
 
     tracing::info!("Deleted instance: {}", name);
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Admin: correct an instance's stored configuration without touching its data.
+///
+/// Every field is optional and only the ones present are changed. Unlike the restart
+/// upgrade path this never runs `down -v`, exports nothing and restores nothing, so the
+/// volumes are left exactly as they are. Use it to repair an instance whose recorded
+/// service_type or image is wrong — restoring the *contents* of a volume is a backup
+/// concern and stays separate.
+#[derive(Deserialize, utoipa::ToSchema)]
+struct PatchInstanceRequest {
+    /// "openclaw" or "ironclaw".
+    #[serde(default)]
+    service_type: Option<String>,
+    /// Full digest reference, e.g. `nearaidev/ironclaw-nearai-worker@sha256:46c3…`.
+    #[serde(default)]
+    image: Option<String>,
+    #[serde(default)]
+    nearai_api_url: Option<String>,
+    #[serde(default)]
+    nearai_api_key: Option<String>,
+    #[serde(default)]
+    ssh_pubkey: Option<String>,
+    #[serde(default)]
+    mem_limit: Option<String>,
+    #[serde(default)]
+    cpus: Option<String>,
+    #[serde(default)]
+    storage_size: Option<String>,
+    /// Merged into the existing extra_env. A null value removes that key.
+    #[serde(default)]
+    extra_env: Option<HashMap<String, Option<String>>>,
+    /// Recreate the container so the new .env takes effect. Named volumes are kept.
+    /// Without this the changes are written and apply the next time it is recreated.
+    #[serde(default)]
+    recreate: Option<bool>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+struct PatchInstanceResponse {
+    name: String,
+    service_type: Option<String>,
+    image: Option<String>,
+    recreated: bool,
+}
+
+#[utoipa::path(patch, path = "/instances/{name}", tag = "Instances",
+    params(("name" = String, Path, description = "Instance name")),
+    request_body = PatchInstanceRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Updated configuration", body = PatchInstanceResponse),
+        (status = 400, description = "Invalid field, or service_type and image name different products", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 404, description = "Instance not found", body = ErrorResponse),
+    )
+)]
+async fn patch_instance(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(req): Json<PatchInstanceRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let inst = {
+        let store = state.store.read().await;
+        store.get(&name).cloned()
+    }
+    .ok_or_else(|| ApiError::NotFound(format!("Instance '{}' not found", name)))?;
+
+    let mut updated = inst.clone();
+
+    if let Some(st) = req.service_type.as_deref().map(str::trim) {
+        if st != "openclaw" && st != "ironclaw" {
+            return Err(ApiError::BadRequest(
+                "service_type must be 'openclaw' or 'ironclaw'".into(),
+            ));
+        }
+        updated.service_type = Some(st.to_string());
+    }
+    if let Some(img) = req.image.as_deref().map(str::trim) {
+        validate_image(img)?;
+        reject_newlines("image", img)?;
+        updated.image = Some(img.to_string());
+        // The digest is only meaningful for the image it was resolved from.
+        updated.image_digest = None;
+    }
+
+    // ensure_env_file replaces an image that contradicts the service_type, which would
+    // silently discard whichever of the two was just asked for. Say so instead.
+    if let (Some(st), Some(named)) = (
+        updated.service_type.as_deref(),
+        state
+            .compose
+            .service_type_named_by_image(updated.image.as_deref()),
+    ) {
+        if st != named {
+            return Err(ApiError::BadRequest(format!(
+                "service_type '{}' and image '{}' name different products; \
+                 pass both so they agree",
+                st,
+                updated.image.as_deref().unwrap_or("")
+            )));
+        }
+    }
+
+    for (field, value) in [
+        ("nearai_api_url", &req.nearai_api_url),
+        ("nearai_api_key", &req.nearai_api_key),
+        ("ssh_pubkey", &req.ssh_pubkey),
+        ("mem_limit", &req.mem_limit),
+        ("cpus", &req.cpus),
+        ("storage_size", &req.storage_size),
+    ] {
+        if let Some(v) = value {
+            reject_newlines(field, v)?;
+        }
+    }
+    if let Some(url) = req.nearai_api_url {
+        updated.nearai_api_url = Some(url);
+    }
+    if let Some(key) = req.nearai_api_key {
+        updated.nearai_api_key = key;
+    }
+    if let Some(pubkey) = req.ssh_pubkey {
+        updated.ssh_pubkey = pubkey;
+    }
+    if let Some(mem) = req.mem_limit {
+        updated.mem_limit = Some(mem);
+    }
+    if let Some(cpus) = req.cpus {
+        updated.cpus = Some(cpus);
+    }
+    if let Some(storage) = req.storage_size {
+        updated.storage_size = Some(storage);
+    }
+    if let Some(patch) = req.extra_env {
+        let mut extra = updated.extra_env.unwrap_or_default();
+        for (k, v) in patch {
+            reject_newlines("extra_env key", &k)?;
+            match v {
+                Some(v) => {
+                    reject_newlines("extra_env value", &v)?;
+                    extra.insert(k, v);
+                }
+                None => {
+                    extra.remove(&k);
+                }
+            }
+        }
+        updated.extra_env = (!extra.is_empty()).then_some(extra);
+    }
+
+    let service_type = updated.service_type.clone();
+    let default_image = match service_type.as_deref() {
+        Some("ironclaw") => state.config.ironclaw_image.clone(),
+        _ => state.config.openclaw_image.clone(),
+    };
+
+    {
+        let compose = state.compose.clone();
+        let inst = updated.clone();
+        let domain = state.config.openclaw_domain.clone();
+        let client_id = state.config.google_oauth_client_id.clone();
+        let exchange_url = state.oauth_exchange_url.clone();
+        tokio::task::spawn_blocking(move || {
+            compose.ensure_env_file(
+                &inst,
+                &default_image,
+                domain.as_deref(),
+                client_id.as_deref(),
+                exchange_url.as_deref(),
+            )
+        })
+        .await
+        .map_err(|e| ApiError::Internal(format!("env file task join: {}", e)))??;
+    }
+
+    {
+        let mut store = state.store.write().await;
+        store.add(updated.clone());
+    }
+
+    let recreate = req.recreate.unwrap_or(false);
+    if recreate {
+        state
+            .compose_start(&name, true, service_type.as_deref())
+            .await?;
+    }
+
+    tracing::info!(
+        "Patched instance '{}': service_type={:?}, recreated={}",
+        name,
+        updated.service_type,
+        recreate
+    );
+
+    Ok(Json(PatchInstanceResponse {
+        name,
+        service_type: updated.service_type,
+        image: updated.image,
+        recreated: recreate,
+    }))
 }
 
 #[utoipa::path(post, path = "/instances/{name}/restart", tag = "Instances",
@@ -6596,6 +6802,7 @@ exit 1
         let app = Router::new()
             .route("/admin/orphans", delete(delete_all_orphans))
             .route("/admin/orphans/{name}", delete(delete_orphan))
+            .route("/instances/{name}", patch(patch_instance))
             .with_state(state);
 
         TestAdminApp {
@@ -6678,6 +6885,111 @@ exit 1
             .body(Body::empty())
             .unwrap();
 
+        let response = test_app.app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    async fn patch_tracked_inst(
+        body: serde_json::Value,
+    ) -> (StatusCode, String, tempfile::TempDir) {
+        use axum::body::{to_bytes, Body};
+        use tower::ServiceExt;
+
+        let test_app = test_admin_app();
+        let request = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/instances/tracked-inst")
+            .header("Authorization", format!("Bearer {}", test_app.token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let response = test_app.app.oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (
+            status,
+            String::from_utf8_lossy(&bytes).to_string(),
+            test_app.env_dir,
+        )
+    }
+
+    /// The repair an instance needs when its recorded type drifted from what it runs:
+    /// set both, write them to the .env, leave the volumes alone.
+    #[tokio::test]
+    async fn test_patch_instance_writes_service_type_and_image_to_env_file() {
+        let image = "nearaidev/ironclaw-nearai-worker@sha256:46c302d3";
+        let (status, body, env_dir) = patch_tracked_inst(serde_json::json!({
+            "service_type": "ironclaw",
+            "image": image,
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["service_type"], "ironclaw");
+        assert_eq!(json["recreated"], false, "recreate defaults to off");
+
+        let written = std::fs::read_to_string(env_dir.path().join("tracked-inst.env")).unwrap();
+        assert!(written.contains("SERVICE_TYPE=ironclaw"), "{}", written);
+        assert!(
+            written.contains(&format!("OPENCLAW_IMAGE={}", image)),
+            "{}",
+            written
+        );
+    }
+
+    #[tokio::test]
+    async fn test_patch_instance_rejects_service_type_that_contradicts_the_image() {
+        let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+            "service_type": "ironclaw",
+            "image": "nearaidev/openclaw-nearai-worker@sha256:deadbeef",
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{}", body);
+        assert!(body.contains("name different products"), "{}", body);
+    }
+
+    #[tokio::test]
+    async fn test_patch_instance_rejects_image_without_a_digest() {
+        let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+            "image": "nearaidev/ironclaw-nearai-worker:latest",
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{}", body);
+        assert!(body.contains("digest reference"), "{}", body);
+    }
+
+    #[tokio::test]
+    async fn test_patch_instance_merges_extra_env_and_drops_null_keys() {
+        let (status, body, env_dir) = patch_tracked_inst(serde_json::json!({
+            "extra_env": {"CHANNEL_RELAY_URL": "https://relay.example", "GONE": null},
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let written = std::fs::read_to_string(env_dir.path().join("tracked-inst.env")).unwrap();
+        assert!(
+            written.contains("CHANNEL_RELAY_URL=https://relay.example"),
+            "{}",
+            written
+        );
+        assert!(!written.contains("GONE="), "{}", written);
+    }
+
+    #[tokio::test]
+    async fn test_patch_instance_requires_admin_auth() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let test_app = test_admin_app();
+        let request = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/instances/tracked-inst")
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"service_type":"ironclaw"}"#))
+            .unwrap();
         let response = test_app.app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -6807,7 +6807,6 @@ exit 1
             ComposeManager::new(compose_files, env_dir.path().to_path_buf(), None).unwrap(),
         );
 
-        let instance = instance;
         let mut instance_store = store::InstanceStore::new(PortRange::from_env());
         instance_store.populate(vec![instance]);
 

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -2745,6 +2745,12 @@ struct PatchInstanceResponse {
     name: String,
     service_type: Option<String>,
     image: Option<String>,
+    /// Whether a SECRETS_MASTER_KEY was readable *before* the recreate, on an instance the
+    /// patch leaves as ironclaw; absent for openclaw, which has no such key. `false` means
+    /// ironclaw minted a fresh one as it came up, so whatever the instance had already
+    /// encrypted stays unreadable and a backup from before the drift is the only copy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    master_key_present: Option<bool>,
 }
 
 #[utoipa::path(patch, path = "/instances/{name}", tag = "Instances",
@@ -2833,6 +2839,50 @@ async fn patch_instance(
         updated.extra_env = (!extra.is_empty()).then_some(extra);
     }
 
+    // ironclaw reads its master key off the config volume and mints a fresh one when the file
+    // is not there, which leaves everything it had already encrypted unreadable. The recreate
+    // below is the moment that happens, so resolve the key first, while the container being
+    // repaired is still the one holding it — the volume is the same at either mount point.
+    // Caching it on the instance also puts it in the .env, where /migrate's preflight reads
+    // it. Reported either way: an absent key is the caller's signal to restore from a backup
+    // taken before the drift instead of trusting this volume.
+    let ironclaw = compose::is_ironclaw(updated.service_type.as_deref(), updated.image.as_deref());
+    let mut master_key_present = updated
+        .extra_env
+        .as_ref()
+        .is_some_and(|e| e.contains_key("SECRETS_MASTER_KEY"));
+    if ironclaw && !master_key_present {
+        let compose = state.compose.clone();
+        let owned_name = name.clone();
+        let container_name = format!("openclaw-{}-gateway-1", name);
+        let signal_type = updated.service_type.clone();
+        let signal_image = updated.image.clone();
+        let key = tokio::task::spawn_blocking(move || {
+            compose.resolve_master_key(
+                &owned_name,
+                &container_name,
+                signal_type.as_deref(),
+                signal_image.as_deref(),
+            )
+        })
+        .await
+        .map_err(|e| ApiError::Internal(format!("master key task join: {}", e)))?;
+        match key {
+            Some(key) => {
+                updated
+                    .extra_env
+                    .get_or_insert_with(Default::default)
+                    .insert("SECRETS_MASTER_KEY".to_string(), key);
+                master_key_present = true;
+            }
+            None => tracing::warn!(
+                "Instance '{}': no SECRETS_MASTER_KEY to carry through the recreate — ironclaw \
+                 will mint one, and anything already encrypted stays unreadable",
+                name
+            ),
+        }
+    }
+
     let service_type = updated.service_type.clone();
     let default_image = match service_type.as_deref() {
         Some("ironclaw") => state.config.ironclaw_image.clone(),
@@ -2889,6 +2939,7 @@ async fn patch_instance(
         name,
         service_type: updated.service_type,
         image: updated.image,
+        master_key_present: ironclaw.then_some(master_key_present),
     }))
 }
 
@@ -6917,14 +6968,38 @@ exit 1
         dir
     }
 
+    /// A fake docker that answers `cat <path>` with `key` and fails for any other path, so a
+    /// test can say which mount point the config volume's `.master_key` is reachable through.
+    fn write_docker_serving_master_key(path: &str, key: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = dir.path().join("docker");
+        std::fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\ncase \"$*\" in\n  *\"{path}\"*) echo {key} ;;\n                   *\".master_key\"*) echo 'no such file' >&2; exit 1 ;;\nesac\nexit 0\n"
+            ),
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+        dir
+    }
+
     async fn patch_tracked_inst(
         body: serde_json::Value,
+    ) -> (StatusCode, String, tempfile::TempDir) {
+        patch_tracked_inst_with_docker(body, write_accepting_docker()).await
+    }
+
+    async fn patch_tracked_inst_with_docker(
+        body: serde_json::Value,
+        docker_dir: tempfile::TempDir,
     ) -> (StatusCode, String, tempfile::TempDir) {
         use axum::body::{to_bytes, Body};
         use tower::ServiceExt;
 
         let _lock = orphan_test_env_lock().lock().await;
-        let docker_dir = write_accepting_docker();
         let _docker_guard = EnvVarGuard::set_path(
             "OPENCLAW_TEST_DOCKER_BIN",
             docker_dir.path().join("docker").as_path(),
@@ -7130,6 +7205,63 @@ exit 1
             "recreate did not use the ironclaw template; docker argv was:\n{}",
             argv
         );
+    }
+
+    /// The repair's own hazard: ironclaw mints a fresh master key when the file is missing, so
+    /// the key has to be read before the recreate — and on a flipped instance it is readable
+    /// only through openclaw's mount point, because that is where its image puts the volume.
+    #[tokio::test]
+    async fn test_patch_instance_carries_a_flipped_instances_master_key_through_the_recreate() {
+        let key = "a".repeat(64);
+        let docker = write_docker_serving_master_key("/home/agent/.openclaw/.master_key", &key);
+        let (status, body, env_dir) = patch_tracked_inst_with_docker(
+            serde_json::json!({
+                "service_type": "ironclaw",
+                "image": "nearaidev/ironclaw-nearai-worker@sha256:46c302d3",
+            }),
+            docker,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["master_key_present"], true, "{}", body);
+
+        let written = std::fs::read_to_string(env_dir.path().join("tracked-inst.env")).unwrap();
+        assert!(
+            written.contains(&format!("SECRETS_MASTER_KEY={}", key)),
+            "{}",
+            written
+        );
+    }
+
+    /// An instance with no key anywhere still gets repaired — the caller is told, because that
+    /// is the case where the volume is not the copy to trust.
+    #[tokio::test]
+    async fn test_patch_instance_reports_a_master_key_it_could_not_find() {
+        let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+            "service_type": "ironclaw",
+            "image": "nearaidev/ironclaw-nearai-worker@sha256:46c302d3",
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["master_key_present"], false, "{}", body);
+    }
+
+    /// openclaw has no such key, so the field says nothing rather than saying "missing".
+    #[tokio::test]
+    async fn test_patch_instance_omits_the_master_key_verdict_for_openclaw() {
+        let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+            "service_type": "openclaw",
+            "image": "nearaidev/openclaw-nearai-worker@sha256:deadbeef",
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(json.get("master_key_present").is_none(), "{}", body);
     }
 
     #[tokio::test]

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -2818,15 +2818,14 @@ async fn patch_instance(
                     k
                 )));
             }
-            match v {
-                Some(v) => {
-                    reject_newlines("extra_env value", &v)?;
-                    extra.insert(k, v);
-                }
-                None => {
-                    extra.remove(&k);
-                }
+            if let Some(v) = v {
+                reject_newlines("extra_env value", &v)?;
+                extra.insert(k, v);
+                continue;
             }
+
+            // null removes the key
+            extra.remove(&k);
         }
         updated.extra_env = (!extra.is_empty()).then_some(extra);
     }

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -1989,6 +1989,16 @@ pub fn is_valid_instance_name(name: &str) -> bool {
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
+/// Whether a string is safe to use as a key in the `.env`. The file is written as
+/// `KEY=value` and parsed back with a trim and `split_once('=')`, so any key containing
+/// '=' or surrounding whitespace would come back as a different key than the one that was
+/// checked. Restricting to a conventional env name rules that out.
+fn is_valid_env_key(key: &str) -> bool {
+    !key.is_empty()
+        && !key.starts_with(|c: char| c.is_ascii_digit())
+        && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 fn reject_newlines(field: &str, value: &str) -> Result<(), ApiError> {
     if value.contains('\n') || value.contains('\r') {
         return Err(ApiError::BadRequest(format!(
@@ -2809,7 +2819,17 @@ async fn patch_instance(
     if let Some(patch) = req.extra_env {
         let mut extra = updated.extra_env.unwrap_or_default();
         for (k, v) in patch {
-            reject_newlines("extra_env key", &k)?;
+            // The .env is written as `KEY=value` and read back with a trim plus
+            // `split_once('=')`, so a key carrying '=' or leading space parses as a
+            // different, shorter key — `SSH_PUBKEY=x` would set SSH_PUBKEY and walk
+            // straight past the managed-key check below. Only accept a plain env name.
+            if !is_valid_env_key(&k) {
+                return Err(ApiError::BadRequest(format!(
+                    "extra_env key '{}' is not a valid environment variable name \
+                     (letters, digits and underscore; must not start with a digit)",
+                    k
+                )));
+            }
             if compose::is_managed_env_key(&k) {
                 return Err(ApiError::BadRequest(format!(
                     "extra_env may not set '{}': compose-api manages it, and extra_env is \
@@ -2859,11 +2879,20 @@ async fn patch_instance(
         store.add(updated.clone());
     }
 
+    // Recreate with the type `ensure_env_file` just settled on, not the one the store
+    // happened to hold: it resolves an unset service_type from the image, and picking the
+    // compose template from the stale value would mount an ironclaw instance through the
+    // openclaw template — the wrong paths for its data.
+    let recreate_type = state
+        .compose
+        .read_service_type_from_env_file(&name)
+        .or(service_type);
+
     // Discovery rebuilds every instance from its container on each compose-api start and
     // rewrites the .env from that, so a change written to the .env alone lasts only until
     // then. Recreating is what makes the patch stick.
     state
-        .compose_start(&name, true, service_type.as_deref())
+        .compose_start(&name, true, recreate_type.as_deref())
         .await?;
 
     tracing::info!(
@@ -6609,6 +6638,10 @@ mod tests {
         token: String,
         env_dir: tempfile::TempDir,
         orphan_cleaning: Arc<Mutex<HashSet<String>>>,
+        /// Distinct from the openclaw template, so which one a recreate used is visible
+        /// in the recorded docker argv.
+        ironclaw_compose: std::path::PathBuf,
+        _compose_dir: tempfile::TempDir,
     }
 
     fn write_fake_docker(volume_names: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
@@ -6725,18 +6758,8 @@ exit 1
         (dir, log_path)
     }
 
-    fn test_admin_app() -> TestAdminApp {
-        let config = AppConfig::test_default();
-        let admin_token = "a".repeat(32);
-        let env_dir = tempfile::tempdir().unwrap();
-
-        let mut compose_files = std::collections::HashMap::new();
-        compose_files.insert("openclaw".to_string(), config.compose_file.clone());
-        let compose = Arc::new(
-            ComposeManager::new(compose_files, env_dir.path().to_path_buf(), None).unwrap(),
-        );
-
-        let instance = Instance {
+    fn default_test_instance() -> Instance {
+        Instance {
             name: "tracked-inst".to_string(),
             token: "test-token".to_string(),
             gateway_port: 19001,
@@ -6753,8 +6776,38 @@ exit 1
             cpus: None,
             storage_size: None,
             extra_env: None,
-        };
+        }
+    }
 
+    fn test_admin_app() -> TestAdminApp {
+        test_admin_app_with(test_instance_named("tracked-inst", Some("openclaw")))
+    }
+
+    /// An instance with only the fields these tests care about set.
+    fn test_instance_named(name: &str, service_type: Option<&str>) -> Instance {
+        let mut inst = default_test_instance();
+        inst.name = name.to_string();
+        inst.service_type = service_type.map(str::to_string);
+        inst
+    }
+
+    fn test_admin_app_with(instance: Instance) -> TestAdminApp {
+        let config = AppConfig::test_default();
+        let admin_token = "a".repeat(32);
+        let env_dir = tempfile::tempdir().unwrap();
+
+        // A distinct ironclaw template, so picking the wrong one is observable.
+        let compose_dir = tempfile::tempdir().unwrap();
+        let ironclaw_compose = compose_dir.path().join("docker-compose.ironclaw.yml");
+        std::fs::write(&ironclaw_compose, "services: {}\n").unwrap();
+        let mut compose_files = std::collections::HashMap::new();
+        compose_files.insert("openclaw".to_string(), config.compose_file.clone());
+        compose_files.insert("ironclaw".to_string(), ironclaw_compose.clone());
+        let compose = Arc::new(
+            ComposeManager::new(compose_files, env_dir.path().to_path_buf(), None).unwrap(),
+        );
+
+        let instance = instance;
         let mut instance_store = store::InstanceStore::new(PortRange::from_env());
         instance_store.populate(vec![instance]);
 
@@ -6783,6 +6836,8 @@ exit 1
             token: admin_token,
             env_dir,
             orphan_cleaning,
+            ironclaw_compose,
+            _compose_dir: compose_dir,
         }
     }
 
@@ -6867,7 +6922,12 @@ exit 1
     fn write_accepting_docker() -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         let script_path = dir.path().join("docker");
-        std::fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let log_path = dir.path().join("argv.log");
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/sh\necho \"$@\" >> {}\nexit 0\n", log_path.display()),
+        )
+        .unwrap();
         let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
         std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
         std::fs::set_permissions(&script_path, perms).unwrap();
@@ -7015,6 +7075,91 @@ exit 1
             );
             assert!(body.contains("compose-api manages it"), "{}", body);
         }
+    }
+
+    /// The .env round-trips through a trim and `split_once('=')`, so a key carrying '='
+    /// or leading space would be checked under one name and written under another —
+    /// setting a managed key without ever failing `is_managed_env_key`.
+    #[tokio::test]
+    async fn test_patch_instance_rejects_env_keys_that_reparse_as_another_key() {
+        for key in [
+            "SSH_PUBKEY=ssh-ed25519 AAAAevil",
+            " SSH_PUBKEY",
+            "SSH_PUBKEY ",
+            "FOO=BAR",
+            "",
+            "1LEADING_DIGIT",
+            "has-dash",
+        ] {
+            let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+                "extra_env": { key: "x" },
+            }))
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "key {:?} was accepted: {}",
+                key,
+                body
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_valid_env_key_accepts_only_plain_names() {
+        assert!(is_valid_env_key("LLM_BASE_URL"));
+        assert!(is_valid_env_key("_private"));
+        assert!(is_valid_env_key("A1"));
+        assert!(!is_valid_env_key("SSH_PUBKEY=x"));
+        assert!(!is_valid_env_key(" SSH_PUBKEY"));
+        assert!(!is_valid_env_key("SSH PUBKEY"));
+        assert!(!is_valid_env_key(""));
+        assert!(!is_valid_env_key("1BAD"));
+    }
+
+    /// The compose template is chosen from the type the .env ended up with. When the store
+    /// has no service_type but the image names ironclaw, the recreate must not fall back to
+    /// the openclaw template — that mounts the instance's volumes at the wrong paths.
+    #[tokio::test]
+    async fn test_patch_instance_recreates_with_the_type_written_to_the_env_file() {
+        use axum::body::{to_bytes, Body};
+        use tower::ServiceExt;
+
+        let _lock = orphan_test_env_lock().lock().await;
+        let docker_dir = write_accepting_docker();
+        let _docker_guard = EnvVarGuard::set_path(
+            "OPENCLAW_TEST_DOCKER_BIN",
+            docker_dir.path().join("docker").as_path(),
+        );
+
+        let test_app = test_admin_app_with(test_instance_named("typeless-inst", None));
+        let request = axum::http::Request::builder()
+            .method("PATCH")
+            .uri("/instances/typeless-inst")
+            .header("Authorization", format!("Bearer {}", test_app.token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(
+                serde_json::json!({ "image": "nearaidev/ironclaw-nearai-worker@sha256:46c302d3" })
+                    .to_string(),
+            ))
+            .unwrap();
+
+        let response = test_app.app.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes).to_string();
+        assert_eq!(status, StatusCode::OK, "{}", body);
+
+        let written =
+            std::fs::read_to_string(test_app.env_dir.path().join("typeless-inst.env")).unwrap();
+        assert!(written.contains("SERVICE_TYPE=ironclaw"), "{}", written);
+
+        let argv = std::fs::read_to_string(docker_dir.path().join("argv.log")).unwrap_or_default();
+        assert!(
+            argv.contains(test_app.ironclaw_compose.to_str().unwrap()),
+            "recreate did not use the ironclaw template; docker argv was:\n{}",
+            argv
+        );
     }
 
     #[tokio::test]

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -2706,11 +2706,15 @@ async fn delete_instance(
 
 /// Admin: correct an instance's stored configuration without touching its data.
 ///
-/// Every field is optional and only the ones present are changed. Unlike the restart
-/// upgrade path this never runs `down -v`, exports nothing and restores nothing, so the
-/// volumes are left exactly as they are. Use it to repair an instance whose recorded
-/// service_type or image is wrong — restoring the *contents* of a volume is a backup
-/// concern and stays separate.
+/// Every field is optional and only the ones present are changed. The container is then
+/// recreated, because that is the only way a change lasts: discovery rebuilds each
+/// instance from its container on every compose-api start and rewrites the .env from
+/// that, so a .env the container does not agree with is reverted at the next restart.
+///
+/// Unlike the restart upgrade path this never runs `down -v`, exports nothing and
+/// restores nothing, so the named volumes carry over untouched. Use it to repair an
+/// instance whose recorded service_type or image is wrong — restoring the *contents* of
+/// a volume is a backup concern and stays separate.
 ///
 /// Deliberately absent: `ssh_pubkey`, `nearai_api_key` and `nearai_api_url`. Those decide
 /// who gets a shell in the container and where it sends the tenant's traffic, so setting
@@ -2734,10 +2738,6 @@ struct PatchInstanceRequest {
     /// allowing them here would let this set SSH_PUBKEY or NEARAI_API_URL by another route.
     #[serde(default)]
     extra_env: Option<HashMap<String, Option<String>>>,
-    /// Recreate the container so the new .env takes effect. Named volumes are kept.
-    /// Without this the changes are written and apply the next time it is recreated.
-    #[serde(default)]
-    recreate: Option<bool>,
 }
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -2745,7 +2745,6 @@ struct PatchInstanceResponse {
     name: String,
     service_type: Option<String>,
     image: Option<String>,
-    recreated: bool,
 }
 
 #[utoipa::path(patch, path = "/instances/{name}", tag = "Instances",
@@ -2860,25 +2859,23 @@ async fn patch_instance(
         store.add(updated.clone());
     }
 
-    let recreate = req.recreate.unwrap_or(false);
-    if recreate {
-        state
-            .compose_start(&name, true, service_type.as_deref())
-            .await?;
-    }
+    // Discovery rebuilds every instance from its container on each compose-api start and
+    // rewrites the .env from that, so a change written to the .env alone lasts only until
+    // then. Recreating is what makes the patch stick.
+    state
+        .compose_start(&name, true, service_type.as_deref())
+        .await?;
 
     tracing::info!(
-        "Patched instance '{}': service_type={:?}, recreated={}",
+        "Patched instance '{}': service_type={:?}",
         name,
-        updated.service_type,
-        recreate
+        updated.service_type
     );
 
     Ok(Json(PatchInstanceResponse {
         name,
         service_type: updated.service_type,
         image: updated.image,
-        recreated: recreate,
     }))
 }
 
@@ -6865,11 +6862,30 @@ exit 1
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    /// A docker that accepts everything, so the recreate at the end of a patch succeeds
+    /// without a real daemon.
+    fn write_accepting_docker() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = dir.path().join("docker");
+        std::fs::write(&script_path, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+        dir
+    }
+
     async fn patch_tracked_inst(
         body: serde_json::Value,
     ) -> (StatusCode, String, tempfile::TempDir) {
         use axum::body::{to_bytes, Body};
         use tower::ServiceExt;
+
+        let _lock = orphan_test_env_lock().lock().await;
+        let docker_dir = write_accepting_docker();
+        let _docker_guard = EnvVarGuard::set_path(
+            "OPENCLAW_TEST_DOCKER_BIN",
+            docker_dir.path().join("docker").as_path(),
+        );
 
         let test_app = test_admin_app();
         let request = axum::http::Request::builder()
@@ -6903,7 +6919,6 @@ exit 1
         assert_eq!(status, StatusCode::OK, "{}", body);
         let json: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(json["service_type"], "ironclaw");
-        assert_eq!(json["recreated"], false, "recreate defaults to off");
 
         let written = std::fs::read_to_string(env_dir.path().join("tracked-inst.env")).unwrap();
         assert!(written.contains("SERVICE_TYPE=ironclaw"), "{}", written);

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -2711,6 +2711,16 @@ async fn delete_instance(
 /// volumes are left exactly as they are. Use it to repair an instance whose recorded
 /// service_type or image is wrong — restoring the *contents* of a volume is a backup
 /// concern and stays separate.
+///
+/// Deliberately absent: `ssh_pubkey`, `nearai_api_key` and `nearai_api_url`. Those decide
+/// who gets a shell in the container and where it sends the tenant's traffic, so setting
+/// them is granting access rather than repairing a record, and nothing about a drifted
+/// service_type needs them. There is no other route to change them on a live instance
+/// today, and this should not become the first one.
+///
+/// Also absent: `mem_limit`, `cpus` and `storage_size`. `ensure_env_file` does not write
+/// those — only `up()` does — so accepting them here would update the in-memory instance
+/// and never reach the .env, which is a silent no-op rather than a limit change.
 #[derive(Deserialize, utoipa::ToSchema)]
 struct PatchInstanceRequest {
     /// "openclaw" or "ironclaw".
@@ -2719,19 +2729,9 @@ struct PatchInstanceRequest {
     /// Full digest reference, e.g. `nearaidev/ironclaw-nearai-worker@sha256:46c3…`.
     #[serde(default)]
     image: Option<String>,
-    #[serde(default)]
-    nearai_api_url: Option<String>,
-    #[serde(default)]
-    nearai_api_key: Option<String>,
-    #[serde(default)]
-    ssh_pubkey: Option<String>,
-    #[serde(default)]
-    mem_limit: Option<String>,
-    #[serde(default)]
-    cpus: Option<String>,
-    #[serde(default)]
-    storage_size: Option<String>,
-    /// Merged into the existing extra_env. A null value removes that key.
+    /// Merged into the existing extra_env. A null value removes that key. Keys compose-api
+    /// manages itself are rejected — extra_env is applied last when the .env is written, so
+    /// allowing them here would let this set SSH_PUBKEY or NEARAI_API_URL by another route.
     #[serde(default)]
     extra_env: Option<HashMap<String, Option<String>>>,
     /// Recreate the container so the new .env takes effect. Named volumes are kept.
@@ -2807,40 +2807,17 @@ async fn patch_instance(
         }
     }
 
-    for (field, value) in [
-        ("nearai_api_url", &req.nearai_api_url),
-        ("nearai_api_key", &req.nearai_api_key),
-        ("ssh_pubkey", &req.ssh_pubkey),
-        ("mem_limit", &req.mem_limit),
-        ("cpus", &req.cpus),
-        ("storage_size", &req.storage_size),
-    ] {
-        if let Some(v) = value {
-            reject_newlines(field, v)?;
-        }
-    }
-    if let Some(url) = req.nearai_api_url {
-        updated.nearai_api_url = Some(url);
-    }
-    if let Some(key) = req.nearai_api_key {
-        updated.nearai_api_key = key;
-    }
-    if let Some(pubkey) = req.ssh_pubkey {
-        updated.ssh_pubkey = pubkey;
-    }
-    if let Some(mem) = req.mem_limit {
-        updated.mem_limit = Some(mem);
-    }
-    if let Some(cpus) = req.cpus {
-        updated.cpus = Some(cpus);
-    }
-    if let Some(storage) = req.storage_size {
-        updated.storage_size = Some(storage);
-    }
     if let Some(patch) = req.extra_env {
         let mut extra = updated.extra_env.unwrap_or_default();
         for (k, v) in patch {
             reject_newlines("extra_env key", &k)?;
+            if compose::is_managed_env_key(&k) {
+                return Err(ApiError::BadRequest(format!(
+                    "extra_env may not set '{}': compose-api manages it, and extra_env is \
+                     applied last when the .env is written",
+                    k
+                )));
+            }
             match v {
                 Some(v) => {
                     reject_newlines("extra_env value", &v)?;
@@ -6976,6 +6953,54 @@ exit 1
             written
         );
         assert!(!written.contains("GONE="), "{}", written);
+    }
+
+    /// Access-granting fields are not part of this endpoint. Serde ignores unknown fields,
+    /// so sending them is accepted but must leave the .env untouched — a caller cannot
+    /// re-key an instance or repoint its traffic through here.
+    #[tokio::test]
+    async fn test_patch_instance_ignores_access_granting_fields() {
+        let (status, body, env_dir) = patch_tracked_inst(serde_json::json!({
+            "service_type": "openclaw",
+            "ssh_pubkey": "ssh-ed25519 AAAAattacker",
+            "nearai_api_key": "sk-attacker",
+            "nearai_api_url": "https://exfil.example/v1",
+        }))
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{}", body);
+        let written = std::fs::read_to_string(env_dir.path().join("tracked-inst.env")).unwrap();
+        assert!(written.contains("SERVICE_TYPE=openclaw"), "{}", written);
+        assert!(!written.contains("AAAAattacker"), "{}", written);
+        assert!(!written.contains("sk-attacker"), "{}", written);
+        assert!(!written.contains("exfil.example"), "{}", written);
+    }
+
+    /// extra_env is written last, so it would otherwise reach the same fields by another
+    /// route — including the master key that decrypts the tenant's secrets.
+    #[tokio::test]
+    async fn test_patch_instance_rejects_extra_env_for_managed_keys() {
+        for key in [
+            "SSH_PUBKEY",
+            "NEARAI_API_URL",
+            "OPENCLAW_IMAGE",
+            "SERVICE_TYPE",
+            "SECRETS_MASTER_KEY",
+            "PATH",
+        ] {
+            let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
+                "extra_env": { key: "attacker-value" },
+            }))
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{} was accepted: {}",
+                key,
+                body
+            );
+            assert!(body.contains("compose-api manages it"), "{}", body);
+        }
     }
 
     #[tokio::test]

--- a/compose-api/src/main.rs
+++ b/compose-api/src/main.rs
@@ -1989,16 +1989,6 @@ pub fn is_valid_instance_name(name: &str) -> bool {
         && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
-/// Whether a string is safe to use as a key in the `.env`. The file is written as
-/// `KEY=value` and parsed back with a trim and `split_once('=')`, so any key containing
-/// '=' or surrounding whitespace would come back as a different key than the one that was
-/// checked. Restricting to a conventional env name rules that out.
-fn is_valid_env_key(key: &str) -> bool {
-    !key.is_empty()
-        && !key.starts_with(|c: char| c.is_ascii_digit())
-        && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
-}
-
 fn reject_newlines(field: &str, value: &str) -> Result<(), ApiError> {
     if value.contains('\n') || value.contains('\r') {
         return Err(ApiError::BadRequest(format!(
@@ -2823,13 +2813,7 @@ async fn patch_instance(
             // `split_once('=')`, so a key carrying '=' or leading space parses as a
             // different, shorter key — `SSH_PUBKEY=x` would set SSH_PUBKEY and walk
             // straight past the managed-key check below. Only accept a plain env name.
-            if !is_valid_env_key(&k) {
-                return Err(ApiError::BadRequest(format!(
-                    "extra_env key '{}' is not a valid environment variable name \
-                     (letters, digits and underscore; must not start with a digit)",
-                    k
-                )));
-            }
+            validate_env_key(&k)?;
             if compose::is_managed_env_key(&k) {
                 return Err(ApiError::BadRequest(format!(
                     "extra_env may not set '{}': compose-api manages it, and extra_env is \
@@ -7087,7 +7071,6 @@ exit 1
             "SSH_PUBKEY ",
             "FOO=BAR",
             "",
-            "1LEADING_DIGIT",
             "has-dash",
         ] {
             let (status, body, _env_dir) = patch_tracked_inst(serde_json::json!({
@@ -7102,18 +7085,6 @@ exit 1
                 body
             );
         }
-    }
-
-    #[test]
-    fn test_is_valid_env_key_accepts_only_plain_names() {
-        assert!(is_valid_env_key("LLM_BASE_URL"));
-        assert!(is_valid_env_key("_private"));
-        assert!(is_valid_env_key("A1"));
-        assert!(!is_valid_env_key("SSH_PUBKEY=x"));
-        assert!(!is_valid_env_key(" SSH_PUBKEY"));
-        assert!(!is_valid_env_key("SSH PUBKEY"));
-        assert!(!is_valid_env_key(""));
-        assert!(!is_valid_env_key("1BAD"));
     }
 
     /// The compose template is chosen from the type the .env ended up with. When the store


### PR DESCRIPTION
Two things: the resolution bug that lets an instance's recorded type drift from what it runs, and the endpoint to repair the ones already drifted.

## The problem

`inspect_container` resolves `service_type` as **label → container env → persisted `.env` → infer from image**. Because the `.env` is read before the image, an instance whose `.env` says `SERVICE_TYPE=openclaw` while its container runs an ironclaw image resolves as `openclaw`.

`ensure_env_file` then takes that answer, sees it disagree with the stored image, and rewrites `OPENCLAW_IMAGE` to the openclaw default:

```
WARN Instance 'quiet-ram': stored image
  'nearaidev/ironclaw-nearai-worker@sha256:46c302d3…' doesn't match service_type 'openclaw',
  using default
INFO Wrote env file for instance quiet-ram
```

The rewrite only touches the `.env`, so nothing changes while the container keeps running. The next recreate — a restart, a migration, a reboot — starts **OpenClaw on the IronClaw instance's home directory**.

The stale value sustains itself: `ensure_env_file` writes `SERVICE_TYPE` back to the `.env`, so every later resolution reads the same wrong answer and rewrites the image again on every compose-api start.

### How the wrong value got there

`SERVICE_TYPE` began being persisted in #91, before #142 added image inference. Any instance compose-api could not identify at that point — no label, no container env, i.e. everything created before ironclaw support in #39 — had `openclaw` written to its `.env` as a fallback. #142 added inference to fix exactly this, but placed it *after* the `.env` read, so it could never reach the instances whose `.env` was already written. #164 then turned the disagreement into the image rewrite.

### Production impact

One day of compose-api logs across the legacy fleet: **329 rewrite warnings covering 143 distinct instances** (93 on cpu03, 50 on cpu04). Each is an ironclaw container with an openclaw image already staged in its `.env`.

Seven were recreated during a migration run and came up as OpenClaw on IronClaw data. Their identity at the moment of recreation is not in doubt — compose-api ran `openclaw --version` against them and it failed, because the binary is not in an ironclaw image:

```
ERROR Internal error: openclaw --version failed:
INFO  Instance 'quiet-ram': master key deferred to GET /instances/quiet-ram
      (service_type=openclaw image_says=ironclaw (disagree))
```

## Commits 1 and 2 — the running image decides

`service_type` exists to select the compose template and the binary to exec, so it has to match the image that is running. The label, the container env and the `.env` file are all copies of an earlier resolution; the image is the thing itself. **It now decides whenever it names a product**, and a disagreement is logged naming the stale value.

Precedence was first changed only against the `.env`, on the assumption that the stale `openclaw` always came from there. That was never established, and it does not hold in general: the label and the container env are both filled from `${SERVICE_TYPE}` at creation, so a container created from an already-poisoned `.env` carries the wrong value in all three places. The fleet logs cannot separate the sources — **no instance has ever reached the inference fallback** in either window examined, which is consistent with any of them. Putting the image ahead of all three removes the assumption instead of betting on it.

- `service_type_named_by_image` returns `None` when the image names neither product — or, ambiguously, both — so it is usable as evidence rather than as a default. `infer_service_type_from_image` keeps its old guessing contract unchanged.
- Resolution moves into `resolve_service_type`, which takes the signals rather than running `docker inspect`. That makes the precedence unit-testable; `inspect_container` shells out directly and could not be covered.
- `.Config.Image` echoes whatever the container was created from — verified against Docker 29.4: a tag stays a tag, a digest reference keeps the repo name, and a bare image id names no product. `OPENCLAW_IMAGE` is consulted as a second source to cover that last case.
- `ensure_env_file` gets the same ordering, and its `"openclaw"` fallback moves last — whatever wins there is persisted and read as fact afterwards, so a guess should be the final resort.

Instances **still running an ironclaw image** resolve as ironclaw on the next compose-api start, stop being rewritten, and get a correct `.env`. That is the bulk of the 143, including all 93 on cpu03, with no per-instance action.

Instances **already recreated on the openclaw image** read as openclaw from their own image, which this cannot distinguish from a genuine openclaw instance. Those need commit 3.

## Commit 3 — `PATCH /instances/{name}`

There was no route for correcting an instance's recorded configuration. `POST /instances/{name}/restart` accepts an image, but its upgrade path exports the volumes, runs `down -v`, recreates and restores — and it refuses outright when the old and new images name different products, which is exactly the state a drifted instance is in.

`PATCH` applies only what the body carries, and never touches data:

```jsonc
{
  "service_type": "ironclaw",
  "image": "nearaidev/ironclaw-nearai-worker@sha256:46c302d3…",  // full digest reference
  "extra_env": { "LLM_BASE_URL": "https://…", "STALE_KEY": null }   // merge; null removes
}
```

It writes the `.env`, updates the stored instance, and **recreates the container**. That is not optional: discovery rebuilds each instance from its container on every compose-api start — image from `.Config.Image`, `extra_env` from the container env — and `ensure_env_file` rewrites the `.env` from that. The `.env` is a cache of what the container *is*, not a record of what it *should be*, so a patch the container does not agree with is reverted at the next restart. With the image now outranking the recorded copies, a staged `service_type` would be overruled by the container's own image too.

Named volumes carry over; nothing is exported, removed or restored — restoring the *contents* of a volume stays a backup concern.

`service_type` and `image` are validated against each other, because `ensure_env_file` replaces an image that contradicts the service_type and would otherwise silently discard whichever of the two the caller just asked for; the 400 names both sides. Images must be digest references, matching create and restart.

### What it deliberately will not do

An earlier revision of this branch also took `ssh_pubkey`, `nearai_api_key` and `nearai_api_url`. Those are not configuration — `ssh_pubkey` decides who gets a shell inside the container, `nearai_api_url` decides where the tenant's prompts and completions are sent. No route exists today to change either on a live instance, repairing a drifted service_type needs neither, and this should not become the first one. They are gone.

Removing the fields alone would have been decorative: `ensure_env_file` applies `extra_env` **after** everything else, so an `extra_env` entry for `SSH_PUBKEY` or `NEARAI_API_URL` replaces the managed value and lands in the same place. `extra_env` therefore refuses any key compose-api manages — `CORE_ENV_KEYS`, `SYSTEM_ENV_KEYS`, and `SECRETS_MASTER_KEY`, which is in neither list but decrypts the tenant's secrets. Non-managed keys still work, which is the point: an agent crash-looping on a bad `LLM_BASE_URL` is fixable without a deploy.

`mem_limit`, `cpus` and `storage_size` are absent for a third reason — only `up()` writes them, `ensure_env_file` does not, and `write_env_file` replaces the whole file. Accepting them would have updated the in-memory instance and never reached the `.env`.

## Commit 4 — the key the recreate would have replaced

The repair carried its own way to lose data. ironclaw takes `SECRETS_MASTER_KEY` from the env, else from `.master_key` on the config volume, else **mints a fresh one and continues** ([`entrypoint.sh:109-119`](https://github.com/nearai/openclaw-nearai-worker/blob/main/ironclaw-worker/entrypoint.sh#L109-L119)) — so the recreate in commit 3 is the moment a still-readable key gets replaced by one that decrypts nothing, with no error anywhere.

`patch_instance` now resolves the key **before** recreating and caches it on the instance, which also writes it to the `.env` where `/migrate`'s preflight reads it. The response says what it found:

```jsonc
{ "name": "quiet-ram", "service_type": "ironclaw", "image": "…", "master_key_present": true }
```

`false` means the recreate minted one and the instance's stored secrets are gone — a backup from before the drift is the only copy. The field is absent for openclaw, which has no such key. Before the recreate is the only moment the answer is readable at all, which is why it is reported here rather than left to a later call.

The key is reachable at that point even on a drifted instance, and this is the part worth checking: both templates mount the **one `config` volume** — [ironclaw at `/home/agent/.ironclaw`](https://github.com/nearai/openclaw-nearai-worker/blob/main/compose-api/docker-compose.ironclaw.yml#L34-L36), [openclaw at `/home/agent/.openclaw`](https://github.com/nearai/openclaw-nearai-worker/blob/main/compose-api/docker-compose.worker.yml#L27-L29) — so an instance recreated onto the openclaw image still carries ironclaw's key, one path over. `resolve_master_key` reads the file at both mount points. openclaw never writes `.master_key`, so the added attempt can only ever return a key the instance already had, and discovery's single cheap exec is left on ironclaw's own path.

That layout also answers what the flip did to the data: openclaw mounted the same volume elsewhere and added files under its own names (`openclaw.json`, `streaming.json`, `skills/`, `identity/`, …), all guarded by `[ ! -f ]`, with no `rm` anywhere in its 317-line entrypoint. It does `chown -R agent:agent` the volume, so `.master_key` sat agent-readable while flipped; ironclaw re-locks it to root 600 on repair.

## Testing

`cargo +stable test --all-features --locked` — **139 passing** (121 before, 18 added). `cargo clippy --all-targets --all-features` clean.

- `test_ensure_env_file_keeps_ironclaw_image_when_env_file_says_openclaw` reproduces the bug: a `.env` saying `openclaw` plus an ironclaw image. **Verified failing on `main`** (`image was rewritten away from ironclaw`) and passing here.
- `test_ensure_env_file_still_repairs_an_image_that_contradicts_a_known_service_type` pins the behaviour that should not change: when `service_type` is known from the container, an openclaw image on an ironclaw instance is still corrected.
- `test_resolve_service_type_prefers_the_image_over_every_recorded_copy` is the precedence test: a stale `openclaw` in the label, in the container env, and in the `.env` each lose to an ironclaw image. **Verified failing** under the old precedence.
- `test_resolve_service_type_falls_back_to_records_when_the_image_names_nothing` covers the bare-image-id container, including `OPENCLAW_IMAGE` recovering the name, and the unchanged final guess.
- `test_resolve_service_type_keeps_agreeing_signals_untouched` pins the common case.
- `test_service_type_named_by_image_reports_unknown_instead_of_guessing` covers the new helper and the unchanged contract of the old one.
- `test_patch_instance_carries_a_flipped_instances_master_key_through_the_recreate` is commit 4's case: a fake docker that serves `.master_key` **only** at openclaw's mount point, asserting the key reaches the `.env` and the response reports it. The two others cover a key found nowhere (`master_key_present: false`, still repaired) and an openclaw patch (field omitted).
- Seven endpoint tests: the `.env` written for a type+image repair, the contradiction 400, the tag-instead-of-digest 400, extra_env merge with null removal, admin auth, that access-granting fields sent anyway leave the `.env` untouched, and that `extra_env` refuses each managed key including `SECRETS_MASTER_KEY`.

## Risk and rollback

Commits 1-2 change behaviour only where the image and the `.env` disagree — today that path always resolves to the `.env` and rewrites the image. Instances with a label or container `SERVICE_TYPE` are untouched, as are those whose signals agree. The first compose-api start after this deploys rewrites affected `.env` files to the correct image and logs a `disagrees with running image` line per instance; that is the intended repair. Rollback is a revert, and any `.env` corrected in the meantime is re-corrupted on the following start.

The endpoint commits are additive — a new route, no existing behaviour changed. It is admin-authenticated like the rest.

The `style:` commit is not part of the change: `cargo fmt --all -- --check` fails on `main` at `backup.rs:105`, which reds the format job on every branch cut from it. Happy to drop it if you would rather fix that separately.

## Not in this PR

Admins reach compose-api through chat-api, so a passthrough there is needed before this endpoint is usable in practice. That is a change in the other repo and a separate step.

