### PR TITLE
ci: run format and test checks on merge_group

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -2,10 +2,7 @@ name: Code Format
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/code-format.yml"
-      - "compose-api/**"
-      - "oauth-service/**"
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,7 @@ name: Test
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/test.yml"
-      - "compose-api/**"
-      - "oauth-service/**"
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/compose-api/src/backup.rs
+++ b/compose-api/src/backup.rs
@@ -105,7 +105,11 @@ impl BackupManager {
     /// Whether the archive exists. A missing object is `Ok(false)`; every other S3 failure —
     /// outage, auth, throttling — propagates as an error, so a caller can 404 a genuinely absent
     /// backup without masking an operational incident as "not found".
-    pub async fn object_exists(&self, instance_name: &str, backup_id: &str) -> Result<bool, ApiError> {
+    pub async fn object_exists(
+        &self,
+        instance_name: &str,
+        backup_id: &str,
+    ) -> Result<bool, ApiError> {
         let key = backup_s3_key(instance_name, backup_id);
 
         match self


### PR DESCRIPTION
## Problem

The merge queue on `main` stalls with:

> Some required checks haven't completed yet — 4 expected required checks.
> `ironclaw-oauth-service format` / `openclaw-compose-api format` / `ironclaw-oauth-service tests` / `openclaw-compose-api tests` — Expected — Waiting for status to be reported

Those four contexts are required by the `Main` ruleset, but `code-format.yml` and `test.yml` only subscribe to `pull_request` and `workflow_dispatch`. The merge queue emits the **`merge_group`** event, so neither workflow runs there, no status is ever posted, and the queue waits out its `check_response_timeout_minutes: 60` before evicting the PR.

## Fix

- Add a `merge_group` trigger to both workflows.
- Drop the `paths` filter. A required status check plus a paths filter leaves the check permanently pending on any PR that doesn't touch `compose-api/` or `oauth-service/` — GitHub treats "workflow never ran" as *not reported*, not as *passed*. `merge_group` doesn't support `paths` filtering either, so the filter had to go regardless.

## Trade-off

The Rust format and test jobs now run on every PR, including docs-only ones. If the extra CI time is noticeable, a follow-up can add `Swatinem/rust-cache@v2` to both jobs.

## Merging this one

The queue is broken for this PR too, since the fix isn't on `main` yet. Either merge with an admin bypass, or queue it — a merge group builds PR + main, so the new triggers apply to its own group and it self-heals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)